### PR TITLE
feat: add .ec-checkbox-row primitive for checkbox+label composition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,6 +487,28 @@ extrachill_enqueue_shared_tabs();
 </div>
 ```
 
+#### Checkbox Row
+
+Canonical "checkbox + label" primitive. Defined in `style.css` (no extra
+asset to enqueue). Use this any time you're composing a checkbox with a
+visible label — especially inside flex/grid containers where the global
+`input[type="checkbox"]` `margin-right` collapses.
+
+```html
+<label class="ec-checkbox-row">
+    <input type="checkbox" />
+    <span>Identify speakers</span>
+    <span class="ec-checkbox-row__hint">adds ~15 min</span>
+</label>
+```
+
+The hint span is optional. The row is a flex container with `gap: var(--spacing-sm)`,
+so the checkbox is correctly spaced from the label in any layout. The
+input's `margin-right` is reset to `0` inside the row, so spacing is
+owned by `gap` alone.
+
+Use this primitive instead of building a bespoke wrapper per surface.
+
 #### Universal Filter Bar Component
 
 Reusable filter bar for archives and lists:

--- a/style.css
+++ b/style.css
@@ -374,6 +374,56 @@ input[type="checkbox"]:disabled {
 	cursor: not-allowed;
 }
 
+/*
+ * Checkbox row primitive — canonical pattern for "checkbox + label" UI.
+ *
+ * The global input[type="checkbox"] rule above sets margin-right on the
+ * input itself, which works for inline-flow text (`<label><input> Text</label>`)
+ * but is collapsed by flexbox / grid containers, leaving the label butted
+ * against the checkbox in any layout-aware consumer (React panes, admin
+ * forms, etc).
+ *
+ * .ec-checkbox-row gives consumers a single class to apply on a wrapping
+ * <label> that:
+ *   - Establishes a flex container with a consistent gap (spacing-sm = 8px)
+ *   - Resets the input's margin so the gap is purely controlled by the row
+ *   - Aligns the checkbox to the first line of the label content
+ *   - Allows multi-line label text + an optional inline hint
+ *
+ * Expected usage:
+ *
+ *     <label class="ec-checkbox-row">
+ *       <input type="checkbox" />
+ *       <span>Identify speakers</span>
+ *       <span class="ec-checkbox-row__hint">adds ~15 min</span>
+ *     </label>
+ *
+ * The hint span is optional — drop it for label-only rows.
+ */
+.ec-checkbox-row {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--spacing-sm);
+	cursor: pointer;
+	padding: var(--spacing-xs) 0;
+	flex-wrap: wrap;
+}
+
+.ec-checkbox-row input[type="checkbox"] {
+	/* Reset the inline-flow margin-right so spacing is purely owned by `gap`. */
+	margin: 0;
+	flex-shrink: 0;
+	/* Nudge the checkbox down to align with the first line of label text. */
+	margin-top: 0.15rem;
+}
+
+.ec-checkbox-row__hint {
+	flex-basis: 100%;
+	margin-left: calc(18px + var(--spacing-sm));  /* checkbox width + gap */
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+}
+
 /* Radio Button Styles */
 input[type="radio"] {
 	appearance: none;


### PR DESCRIPTION
Fixes #20.

## Summary

Adds a canonical `.ec-checkbox-row` primitive to the theme for "checkbox + label" UI. Solves the actual root cause: the global `input[type="checkbox"]` rule uses `margin-right`, which works for inline-flow text but collapses inside flex/grid containers — leaving labels butted against checkboxes in any layout-aware consumer (React panes, admin forms).

## Usage

```html
<label class="ec-checkbox-row">
    <input type="checkbox" />
    <span>Identify speakers</span>
    <span class="ec-checkbox-row__hint">adds ~15 min</span>
</label>
```

The hint span is optional — drop it for label-only rows.

## What the primitive guarantees

- Flex container with `gap: var(--spacing-sm)` so spacing survives any layout context
- Input's `margin-right` reset to 0 inside the row (so the gap value is purely owned by the row, not split between margin + gap)
- `align-items: flex-start` + slight `margin-top` on the input so the checkbox visually aligns with the first line of label text
- `__hint` span has `flex-basis: 100%` so it drops onto its own line with a left margin matching `checkbox-width + gap`, keeping multi-line content aligned

## What this PR does NOT do

- **No new design token.** I considered adding `--checkbox-label-gap` and decided it's not needed — the value is `--spacing-sm` and there's no semantic reason to alias it. The bug was a missing primitive *class*, not a missing token.
- **Doesn't touch the global `input[type="checkbox"]` rule.** Legacy inline-flow usage (form fields with text immediately after the checkbox) keeps working. The new class is purely additive.
- **Doesn't enforce migration.** Consumers can adopt incrementally.

## Files

| File | Change |
|---|---|
| `style.css` | New `.ec-checkbox-row` + `.ec-checkbox-row input[type="checkbox"]` reset + `.ec-checkbox-row__hint` modifier |
| `AGENTS.md` | Document the primitive under Reusable Components |

Net **+~70** lines (mostly the docblock + AGENTS.md prose).

## Test plan

After merge + deploy:

1. Any consumer using `<label class="ec-checkbox-row">` renders a properly-spaced checkbox + label
2. Existing inline checkbox usage in forms still renders with the 8px `margin-right` it always had
3. Studio's Transcribe tab (v0.16.0, follow-up PR in extrachill-studio) adopts the primitive and visually fixes the original report

## Pairs with

- Extra-Chill/extrachill-studio next PR — uses `.ec-checkbox-row` in the Transcribe tab's three-control layout, replacing the locally-styled `__checkbox-label` that doesn't work