### PR TITLE
fix: opt Gutenberg block-preview iframes out of responsive max-width

### DIFF
--- a/style.css
+++ b/style.css
@@ -63,6 +63,17 @@ embed, iframe, object {
 	max-width: 100%;
 }
 
+/* Gutenberg's block preview (hover in the inserter, pattern previews, etc.)
+ * mounts an iframe at a fixed inline width (default 500px) and shrinks it to
+ * fit the surrounding container via `transform: scale(...)`. The responsive
+ * `iframe { max-width: 100% }` rule above breaks that contract — it forces
+ * the iframe's layout width down to the container width, so the scaled-down
+ * render only fills about half the preview popover and the rest is empty.
+ * Opt these preview iframes out so Gutenberg's scale math works as designed. */
+.block-editor-block-preview__container iframe {
+	max-width: none;
+}
+
 /* @font-face declarations are registered via the wp_theme_json_data_theme
  * filter in inc/core/assets.php. WordPress core emits <style> tags via
  * wp_print_font_faces() on wp_head (frontend) and inside the editor iframe


### PR DESCRIPTION
## Problem

In extrachill-studio's compose tab, the Gutenberg inserter preview popover (hover any block, the popover shows a miniature block render + name + description) renders the block in only ~half of the popover width, leaving a big empty white rectangle on the right side.

## Root cause

The theme's responsive media rule:

\`\`\`css
embed, iframe, object {
  max-width: 100%;
}
\`\`\`

is interacting badly with how Gutenberg's \`BlockPreview\` component works.

Gutenberg's preview mounts the block inside an \`<iframe>\` rendered at a **fixed inline \`width: 500px\`** (the synthetic viewport), then visually shrinks it to fit the surrounding container via \`transform: scale(containerWidth / 500)\` on a wrapper. This is intentional — it lets you render a wide-canvas block in a narrow preview panel at the correct aspect ratio.

The responsive \`max-width: 100%\` rule overrides the inline \`width: 500px\` and forces the iframe's **layout width** down to its parent container width (~248px in our case — popover is 280px minus padding). The scale transform then shrinks that already-collapsed iframe further, so the visible render fills only ~123px of the 248px container. The remaining ~125px is empty.

Verified with DevTools width chain inspection:

\`\`\`
IFRAME                    rect=123 comp=248px  (inline style="width: 500px" overridden)
.iframe__scale-container  rect=123 comp=248px
.block-preview__content   rect=123 comp=248px  transform: scale(0.496)
.block-preview__container rect=248 comp=248px
.preview-content          rect=248 comp=248px
\`\`\`

The diagnostic also confirmed the only width-setting CSS rule matching the iframe was the theme's \`embed, iframe, object { max-width: 100% }\`.

## Fix

Add a specificity-0,2,1 override that opts Gutenberg's preview iframes out of the responsive cap:

\`\`\`css
.block-editor-block-preview__container iframe {
  max-width: none;
}
\`\`\`

Scoped to \`.block-editor-block-preview__container\` (the wrapper Gutenberg uses for any block preview iframe — inserter hover, pattern preview, list-view preview, switcher preview). All other iframes on the front-end (oEmbeds, YouTube, video, etc.) continue to be capped by the original responsive rule.

## Test plan

1. Hard-reload studio.extrachill.com compose tab in dark mode (cache-bust the stylesheet).
2. Hover any block (Paragraph, Heading, etc.) in the inserter.
3. Confirm the block render fills the full width of the preview popover instead of cramping into the left half.
4. Confirm front-end pages (any extrachill.com article with an embedded video / oEmbed) still cap embeds responsively at the container width.

## Why not in blocks-everywhere instead?

The bug is in the **theme**'s responsive rule, not in BE or IBE. The same rule would break any other Gutenberg-using context (wp-admin post editor preview popovers, etc.) — fixing it in the theme is the right scope. BE/IBE are doing exactly what Gutenberg expects.