### PR TITLE
refactor: migrate block-editor iframe styles to canonical enqueue_block_assets

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -114,14 +114,22 @@ function extrachill_enqueue_root_styles() {
 add_action( 'wp_enqueue_scripts', 'extrachill_enqueue_root_styles', 5 );
 
 /*
- * Editor iframe styles (root.css, editor-style.css, single-post.css,
+ * Editor iframe styles in wp-admin (root.css, editor-style.css, single-post.css,
  * block-editor.css) are delivered via add_editor_style() in functions.php.
  * That pipeline injects CSS into the iframe via EditorStyles React component
  * without leaking onto the outer wp-admin page.
  *
- * Previously extrachill_enqueue_editor_iframe_styles() used enqueue_block_assets
- * which fires on BOTH the outer admin page and the iframe, causing style.css
- * and block-editor.css to leak onto wp-admin chrome.
+ * For front-end block editor contexts (Blocks Everywhere on bbPress, Studio,
+ * etc.), iframe styles are delivered via the canonical enqueue_block_assets
+ * action below. That hook fires for both host page AND iframe in any
+ * Gutenberg-driven editor context — which is exactly the canonical API
+ * Gutenberg-22.8+ expects for iframe-styles resolution.
+ *
+ * Historical note: enqueue_block_assets fires on EVERY admin page if
+ * unguarded, which previously caused style.css and block-editor.css to leak
+ * onto wp-admin chrome. The guard in extrachill_enqueue_block_editor_iframe_assets
+ * (! is_admin() + class_exists check) keeps the canonical hook scoped to
+ * front-end block-editor consumers only.
  */
 
 function extrachill_enqueue_embed_iframe_styles() {
@@ -164,31 +172,6 @@ function extrachill_enqueue_taxonomy_badges() {
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_enqueue_taxonomy_badges', 10 );
 
-/**
- * Enqueue EC block editor branding on host page when Blocks Everywhere is active.
- *
- * Sources from @extrachill/tokens css/block-editor.css. Styles scoped under
- * .gutenberg-support apply to the host page (toolbar, popovers, sidebar).
- * Iframe styles from the same file are injected via
- * blocks_everywhere_enqueue_iframe_assets.
- */
-function extrachill_enqueue_block_editor_branding() {
-	if ( ! class_exists( 'Automattic\\Blocks_Everywhere\\Blocks_Everywhere' ) ) {
-		return;
-	}
-
-	$block_editor_css_path = get_stylesheet_directory() . '/assets/css/block-editor.css';
-	if ( file_exists( $block_editor_css_path ) ) {
-		wp_enqueue_style(
-			'extrachill-block-editor',
-			get_stylesheet_directory_uri() . '/assets/css/block-editor.css',
-			array( 'extrachill-root' ),
-			filemtime( $block_editor_css_path )
-		);
-	}
-}
-add_action( 'wp_enqueue_scripts', 'extrachill_enqueue_block_editor_branding', 15 );
-
 function extrachill_modify_default_style() {
 	wp_dequeue_style( 'extrachill-style' );
 	wp_deregister_style( 'extrachill-style' );
@@ -202,7 +185,43 @@ function extrachill_modify_default_style() {
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_modify_default_style', 20 );
 
-function extrachill_enqueue_blocks_everywhere_iframe_assets() {
+/**
+ * Enqueue theme styles into block-editor contexts via the canonical Gutenberg API.
+ *
+ * The `enqueue_block_assets` action is Gutenberg's canonical hook for delivering
+ * styles to block-editor contexts. It fires for BOTH the host page AND the
+ * iframe canvas, so a single registration reaches every consumer:
+ *
+ *   - Blocks Everywhere bbPress editors (community.extrachill.com)
+ *   - Studio embedded editors
+ *   - Any future plugin spinning up an iframed block editor
+ *
+ * Before this migration, the theme hooked the BE-specific
+ * `blocks_everywhere_enqueue_iframe_assets` action, which only fired during
+ * BE's __unstableResolvedAssets computation. Other block-editor consumers on
+ * the same page never got the theme's CSS variables (--text-color,
+ * --background-color, etc.) and Gutenberg's iframe-compat layer logged
+ * "added to the iframe incorrectly" warnings while falling back to a clone.
+ *
+ * Context guard: enqueue_block_assets fires on EVERY admin page request. The
+ * wp-admin post editor delivers iframe styles via add_editor_style() (see
+ * functions.php) and absolutely must NOT also get theme styles enqueued onto
+ * the outer admin chrome — that's the regression the historical comment above
+ * warns about. The `! is_admin()` check scopes this to front-end block-editor
+ * consumers only, and the class_exists check keeps the enqueue out of
+ * non-editor front-end pages where it isn't needed.
+ *
+ * @since 2.4.2
+ */
+function extrachill_enqueue_block_editor_iframe_assets() {
+	if ( is_admin() ) {
+		return;
+	}
+
+	if ( ! class_exists( 'Automattic\\Blocks_Everywhere\\Blocks_Everywhere' ) ) {
+		return;
+	}
+
 	$root_css_path = get_stylesheet_directory() . '/assets/css/root.css';
 	if ( file_exists( $root_css_path ) ) {
 		if ( ! wp_style_is( 'extrachill-root', 'registered' ) ) {
@@ -231,7 +250,6 @@ function extrachill_enqueue_blocks_everywhere_iframe_assets() {
 		wp_enqueue_style( 'extrachill-style' );
 	}
 
-	// EC block editor branding (from @extrachill/tokens).
 	$block_editor_css_path = get_stylesheet_directory() . '/assets/css/block-editor.css';
 	if ( file_exists( $block_editor_css_path ) ) {
 		if ( ! wp_style_is( 'extrachill-block-editor', 'registered' ) ) {
@@ -246,7 +264,7 @@ function extrachill_enqueue_blocks_everywhere_iframe_assets() {
 		wp_enqueue_style( 'extrachill-block-editor' );
 	}
 }
-add_action( 'blocks_everywhere_enqueue_iframe_assets', 'extrachill_enqueue_blocks_everywhere_iframe_assets' );
+add_action( 'enqueue_block_assets', 'extrachill_enqueue_block_editor_iframe_assets' );
 
 /**
  * Strip wp-admin-only editor stylesheets from non-admin block editor contexts.


### PR DESCRIPTION
## Summary

Migrate the theme's block-editor iframe stylesheet delivery from the BE-specific `blocks_everywhere_enqueue_iframe_assets` hook to Gutenberg's canonical `enqueue_block_assets` action. This aligns the theme with the Gutenberg-22.8+ iframe-styles API and silences the recently-observed compat-layer warnings on prod.

## Why this matters

Gutenberg's iframe-compat layer was logging "`extrachill-style-css` and `extrachill-block-editor-css` added to the iframe incorrectly" warnings on community.extrachill.com. The styles still reached the iframe (via Gutenberg's clone fallback), but the canonical API is `enqueue_block_assets` — that action fires for **both** host page **and** iframe in any Gutenberg-driven editor context.

The previous BE-specific hook only fired during BE's `__unstableResolvedAssets` computation. Any other block-editor consumer on the page (Studio embedded editors, a future iframed editor) never received the theme's CSS variables (`--text-color`, `--background-color`, etc.) declared in `root.css`. With the canonical hook, a single registration reaches every consumer.

## The change

`inc/core/assets.php`:

- New function `extrachill_enqueue_block_editor_iframe_assets()` hooked to `enqueue_block_assets` — enqueues `extrachill-root`, `extrachill-style`, and `extrachill-block-editor` (in dependency order) using the existing registrations.
- Removed `extrachill_enqueue_blocks_everywhere_iframe_assets()` and its `blocks_everywhere_enqueue_iframe_assets` hook — redundant now.
- Removed `extrachill_enqueue_block_editor_branding()` (was `wp_enqueue_scripts` priority 15) — its host-page concern is also covered by `enqueue_block_assets`, which fires on the host page render too.
- Updated the existing leak-warning comment block to reflect both delivery paths (wp-admin via `add_editor_style()`, front-end via `enqueue_block_assets`).

## Context guard — preventing the wp-admin chrome leak

The historical comment in `assets.php` (lines 116–125 pre-change) warned that an earlier `enqueue_block_assets` enqueue caused `style.css` and `block-editor.css` to leak onto the outer wp-admin page, because the hook fires on **every** admin pageload if unguarded. The wp-admin post editor delivers iframe styles via `add_editor_style()` (registered in `functions.php`) and absolutely must not also get theme styles enqueued onto admin chrome.

The new function guards with two checks:

```php
if ( is_admin() ) {
    return;
}

if ( ! class_exists( 'Automattic\\Blocks_Everywhere\\Blocks_Everywhere' ) ) {
    return;
}
```

- `! is_admin()` scopes the canonical hook to front-end consumers only — wp-admin keeps its existing `add_editor_style()` pipeline untouched.
- The `class_exists` check matches what the removed `extrachill_enqueue_block_editor_branding()` already used. It keeps the enqueue out of front-end pages where BE isn't loaded.

## What this does NOT touch

- `extrachill_enqueue_root_styles()` — front-end concern, unchanged.
- `extrachill_modify_default_style()` — front-end concern, unchanged.
- `extrachill_enqueue_embed_iframe_styles()` — oEmbed iframes, separate pipeline.
- `add_editor_style()` registrations in `functions.php` — wp-admin post editor iframe pipeline, unchanged.
- Per-template archive/single-post/sidebar/search enqueues — front-end concerns, unchanged.

## Note on the removed hook

`blocks_everywhere_enqueue_iframe_assets` still exists in BE itself — BE defines and fires the action regardless. Other consumers can still hook into it. The theme simply no longer needs to, because `enqueue_block_assets` is broader (any iframed editor, not just BE) and canonical.

## Verification

The theme has no test suite. The fix is verifiable only against a live multisite with Blocks Everywhere active.

**Smoke test path:**

1. Load `community.extrachill.com` on a bbPress topic page with BE active. Open DevTools console. The `extrachill-style-css` and `extrachill-block-editor-css` "added to the iframe incorrectly" warnings should be **gone**.
2. Verify the BE editor iframe still has theme CSS variables applied (root.css tokens, style.css typography, block-editor.css branding). The visual result should be identical to before.
3. **Sticky regression check:** load `wp-admin` on `extrachill.com` and confirm the outer admin chrome does NOT have theme styles leaking in (no `extrachill-style-css` or `extrachill-block-editor-css` `<link>` tags on `<body class="wp-admin">`). The historical leak that the original comment warned about must NOT reappear.
4. Load the wp-admin post editor and confirm the post-editor iframe still has theme styles applied via `add_editor_style()` — that pipeline is untouched.

cc @chubes — ready for review