### PR TITLE
fix: modernize block-editor toolbar selectors for current Gutenberg DOM

### DIFF
--- a/assets/css/block-editor.css
+++ b/assets/css/block-editor.css
@@ -16,32 +16,108 @@
  *   - WordPress: enqueue on host page via wp_enqueue_scripts AND
  *     inject into iframe via blocks_everywhere_enqueue_iframe_assets
  *   - Mobile: import alongside tokens-all.css for native editor branding
+ *
+ * Dark mode chain:
+ *   - CSS variables are defined at :root in root.css
+ *   - @media (prefers-color-scheme: dark) in root.css flips those variables
+ *   - Selectors in this file reference variables, so dark mode applies
+ *     automatically without any dark-mode rules here.
  */
 
 
 /* ==========================================================================
-   1. Inserter Buttons — Host Page
-   The toolbar (+) button and empty-block inserter use EC's accent-3 (cyan)
-   instead of the default WP inserter color.
+   1. Block Toolbar — Host React Tree
+   The block toolbar lives in BE's .blocks-everywhere-editor__toolbar wrapper
+   and renders Gutenberg's <BlockToolbar /> as .block-editor-block-toolbar
+   containing .components-toolbar(-group) segments. Default Gutenberg paints
+   these surfaces white via --wp-components-color-background. Override with
+   EC theme tokens so the toolbar respects dark mode.
    ========================================================================== */
 
-/* Toolbar inserter (+) — mirrors EC .button-2 */
-.gutenberg-support .iso-editor .interface-interface-skeleton__header .editor-document-tools__inserter-toggle.is-primary {
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-toolbar,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-toolbar-group {
+    background-color: var(--background-color);
+    color: var(--text-color);
+    border-color: var(--border-color);
+}
+
+/* Toolbar buttons — base color */
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-button,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-toolbar-button {
+    color: var(--text-color);
+}
+
+/* Toolbar buttons — hover / focus */
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-button:hover:not(:disabled, [aria-disabled="true"]),
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-button:focus-visible:not(:disabled, [aria-disabled="true"]),
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-toolbar-button:hover:not(:disabled, [aria-disabled="true"]),
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-toolbar-button:focus-visible:not(:disabled, [aria-disabled="true"]) {
+    color: var(--accent);
+    background-color: transparent;
+}
+
+/* Toolbar buttons — pressed / active */
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-button.is-pressed,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-button[aria-pressed="true"],
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-toolbar-button.is-pressed,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar .components-toolbar-button[aria-pressed="true"] {
+    color: var(--button-text-color);
+    background-color: var(--accent);
+}
+
+/* Toolbar SVG icons inherit button color */
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar svg,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar svg * {
+    fill: currentColor;
+}
+
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-block-toolbar svg [stroke]:not([stroke="none"]) {
+    stroke: currentColor;
+}
+
+
+/* ==========================================================================
+   2. Toolbar Inserter (+) — Host React Tree
+   BE renders <Inserter /> inside .blocks-everywhere-editor__toolbar, which
+   produces .block-editor-inserter > .block-editor-inserter__toggle.components-button.
+   Style it as EC's primary accent button (matches the previous IBE-era
+   .editor-document-tools__inserter-toggle.is-primary rule).
+   ========================================================================== */
+
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter > button.components-button,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter__toggle.components-button {
     background-color: var(--accent);
     border-color: var(--accent);
     color: var(--button-text-color);
     transition: background-color 0.3s ease;
 }
 
-.gutenberg-support .iso-editor .interface-interface-skeleton__header .editor-document-tools__inserter-toggle.is-primary:hover,
-.gutenberg-support .iso-editor .interface-interface-skeleton__header .editor-document-tools__inserter-toggle.is-primary:focus,
-.gutenberg-support .iso-editor .interface-interface-skeleton__header .editor-document-tools__inserter-toggle.is-primary:focus-visible {
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter > button.components-button:hover,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter > button.components-button:focus,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter > button.components-button:focus-visible,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter__toggle.components-button:hover,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter__toggle.components-button:focus,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter__toggle.components-button:focus-visible {
     background-color: var(--accent-hover);
     border-color: var(--accent-hover);
     color: var(--button-text-color);
 }
 
-/* Empty block inserter (host page, when block is selected) */
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter > button.components-button svg,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter__toggle.components-button svg,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter > button.components-button svg *,
+.gutenberg-support .blocks-everywhere-editor__toolbar .block-editor-inserter__toggle.components-button svg * {
+    fill: currentColor;
+}
+
+
+/* ==========================================================================
+   3. Empty Block Inserter — Host Page
+   When a block is selected and the empty-block inserter renders at the host
+   level (outside the iframe), style it with EC's accent-3 (cyan).
+   ========================================================================== */
+
 .gutenberg-support .block-editor-block-list__empty-block-inserter .block-editor-inserter > button.components-button.block-editor-inserter__toggle.has-icon {
     background-color: var(--accent-3);
     border: none;
@@ -68,7 +144,7 @@
 
 
 /* ==========================================================================
-   2. Inserter Buttons — Editor Iframe
+   4. Inserter Buttons — Editor Iframe
    Same accent-3 branding for inserter buttons inside the editor canvas.
    ========================================================================== */
 
@@ -123,7 +199,7 @@
 
 
 /* ==========================================================================
-   3. Placeholder Branding — Editor Iframe
+   5. Placeholder Branding — Editor Iframe
    Embed/image/gallery placeholder blocks use EC card styling.
    ========================================================================== */
 
@@ -190,20 +266,4 @@
 
 .editor-styles-wrapper .components-placeholder svg [stroke]:not([stroke="none"]) {
     stroke: currentColor;
-}
-
-
-/* ==========================================================================
-   4. Footer Branding
-   EC-specific footer styling for the editor status bar.
-   ========================================================================== */
-
-.gutenberg-support .iso-editor .interface-interface-skeleton__footer {
-    padding: var(--spacing-xs) var(--spacing-sm);
-    font-size: var(--font-size-sm);
-    line-height: 1.1;
-}
-
-.gutenberg-support .iso-editor .interface-interface-skeleton__footer .edit-post-layout__footer {
-    padding: 0;
 }


### PR DESCRIPTION
## Diagnosis

`assets/css/block-editor.css` targeted **stale Gutenberg / IBE-era selectors** that no longer match any element in the live DOM rendered by current Gutenberg + Blocks Everywhere (post BE #6 `InterfaceSkeleton` removal and BE #15 `.blocks-everywhere-editor__toolbar` wrapper).

On dark-mode systems, the block toolbar rendered **WHITE** — Gutenberg's default `.components-toolbar { background-color: var(--wp-components-color-background, #fff) }` — because none of the theme's override rules matched anything. The editor canvas (inside the iframe) rendered correctly because PR #25's `enqueue_block_assets` migration already handles iframe-canvas selectors; only the host-tree toolbar was broken.

## Stale selectors removed

- `.interface-interface-skeleton__header` — IBE / old `@wordpress/interface` shell, deleted by BE #6
- `.interface-interface-skeleton__footer` — same; BE renders only a `<Slot name="blocks-everywhere/footer" />`, no skeleton class
- `.iso-editor` — IBE wrapper class, gone
- `.edit-post-header*` — core editor's post-centric header markup, never present in BE
- `.editor-document-tools__inserter-toggle` — replaced by direct `<Inserter />` rendering inside `.blocks-everywhere-editor__toolbar`
- `.edit-post-layout__footer` — dead

## Modern selectors added

**Block toolbar surface** (host React tree, inside `.blocks-everywhere-editor__toolbar`):
- `.block-editor-block-toolbar` — toolbar outer wrapper
- `.block-editor-block-toolbar .components-toolbar` — toolbar segments (the white culprit)
- `.block-editor-block-toolbar .components-toolbar-group` — button groups

**Toolbar buttons:**
- `.block-editor-block-toolbar .components-button` / `.components-toolbar-button` — base color
- `:hover` / `:focus-visible` — accent foreground
- `.is-pressed` / `[aria-pressed="true"]` — accent background + button-text-color foreground
- `svg` / `svg *` — `fill: currentColor` so icons inherit button state

**Toolbar inserter (+):**
- `.blocks-everywhere-editor__toolbar .block-editor-inserter > button.components-button` — accent primary button
- `.blocks-everywhere-editor__toolbar .block-editor-inserter__toggle.components-button` — alternate selector for the same toggle

## Dark-mode chain (load-bearing)

1. CSS variables (`--background-color`, `--text-color`, `--border-color`, `--accent`, etc.) are defined at `:root` in `root.css` (generated artifact from `@extrachill/tokens`).
2. `root.css` ships a `@media (prefers-color-scheme: dark)` override that **flips the same variables** to dark values.
3. The selectors in this PR all reference the variables — they never hardcode colors.

That means: dark mode "just works" without any `prefers-color-scheme` rule in this file. The previous CSS had the same chain in principle, but the selectors didn't match live DOM, so the variables never got applied to the toolbar.

## What was kept untouched

- All `.editor-styles-wrapper` rules (iframe canvas) — current Gutenberg still uses this class for the canvas root; PR #25's enqueue path delivers these correctly.
- All `.components-placeholder` rules — still valid in current Gutenberg.
- All `.block-editor-block-list__empty-block-inserter`, `.block-editor-default-block-appender`, `.block-list-appender__toggle`, `.block-editor-button-block-appender`, `.block-editor-block-list__insertion-point-inserter` selectors — still current.
- The `.gutenberg-support` scope — BE's namespace gate, consumer-side scoping required.

## Smoke test

1. Load `community.extrachill.com` or `studio.extrachill.com` on a BE-active page in a browser set to dark mode (OS preference or DevTools "Emulate CSS prefers-color-scheme: dark").
2. **Expected:** block toolbar renders dark (matching theme `--background-color`), text + icons follow `--text-color`, hover lights up `--accent`, the `+` inserter button is accent-colored.
3. **DevTools inspect** the toolbar → confirm `.block-editor-block-toolbar` matches the new rules, computed `background-color` resolves to the dark token value.
4. Toggle browser to light mode → toolbar flips to light tokens, no flash, no reload needed.

## Hard constraints honored

- No `!important` — all selectors fight specificity via depth + `.gutenberg-support` scope.
- No `@media (prefers-color-scheme: dark)` rules added here — dark mode is owned by `root.css`.
- No edits to `root.css`, `assets.php`, or any other file.
- No `CHANGELOG.md` edits — homeboy owns it.
- No version bump — homeboy auto-detects from the `fix:` prefix.

cc <@532385681268408341> ready for review