### PR TITLE
fix(layout): invert :has() grid so default is single-column (closes #130, theme side)

### DIFF
--- a/style.css
+++ b/style.css
@@ -738,18 +738,23 @@ body {
 	max-width: var(--container-width);
 	width: 100%;
 	box-sizing: border-box;
-	display: grid;
-	grid-template-columns: 1fr var(--sidebar-width);
-	gap: var(--spacing-lg);
+	display: block;
 }
 
 .content-column {
 	min-width: 0;
 }
 
-/* Single column layout when no sidebar */
-.extrachill-content:not(:has(.sidebar)) {
-	display: block;
+/*
+ * Two-column grid only when a sidebar actually renders. Uses :has()
+ * for opt-in (Safari 15.4+, Chrome 105+, Firefox 121+). Browsers
+ * without :has() get single-column treatment, which is the safer
+ * default — never an empty 380px column reserving space.
+ */
+.extrachill-content:has(.sidebar) {
+	display: grid;
+	grid-template-columns: 1fr var(--sidebar-width);
+	gap: var(--spacing-lg);
 }
 
 /*
@@ -1260,7 +1265,7 @@ p.site-title {
 	.mobile-only {
 		display: block;
 	}
-	.extrachill-content {
+	.extrachill-content:has(.sidebar) {
 		grid-template-columns: 1fr; /* single column on mobile */
 	}
 	.extrachill-content .full-width-breakout {


### PR DESCRIPTION
## Summary

Inverts the `.extrachill-content` layout default in the theme so pages
without a sidebar render as single-column block — instead of a two-column
grid that reserves an empty `var(--sidebar-width)` slot and then tries to
collapse with `:not(:has(.sidebar))`.

## Why

On /my-shows/ (and every other page without a sidebar), users were seeing
an empty ~380px column on the right where a sidebar would render. The DOM
had zero `.sidebar` elements, but the grid was still reserving the slot
because `:has()` wasn't doing what it was supposed to — either browser
support, specificity collision, or both. The original logic was correct
in theory and brittle in practice.

## The fix

```diff
-.extrachill-content {
-    display: grid;
-    grid-template-columns: 1fr var(--sidebar-width);
-    gap: var(--spacing-lg);
-}
-
-.extrachill-content:not(:has(.sidebar)) {
-    display: block;
-}
+.extrachill-content {
+    display: block;
+}
+
+.extrachill-content:has(.sidebar) {
+    display: grid;
+    grid-template-columns: 1fr var(--sidebar-width);
+    gap: var(--spacing-lg);
+}
```

Default is now `display: block`. The grid opts in via `:has()` only when
a sidebar actually renders. Browsers without `:has()` support get the
safer single-column treatment everywhere — at worst they lose the
side-by-side layout on archive pages, which is better than getting a
ghost column on /my-shows/.

The mobile breakpoint override at 768px is scoped to the sidebar variant
since the non-sidebar default is already block.

## Acceptance

- /my-shows/ no longer shows empty right-hand space.
- Pages with a sidebar (archives, single posts in some templates) still
  render side-by-side on browsers with `:has()` support.

Closes #130 — theme side. Companion PRs in `extrachill-users` and
`extrachill-events` cover the other two halves.