### PR TITLE
chore(deps): bump @extrachill/tokens to v0.7.2 for info/warning color tokens (closes #6 theme side)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "build": "cp node_modules/@extrachill/tokens/css/root.css assets/css/root.css && node scripts/build-taxonomy-badges.js"
   },
   "dependencies": {
-    "@extrachill/tokens": "^0.5.0"
+    "@extrachill/tokens": "github:Extra-Chill/extrachill-tokens#v0.7.2"
   }
 }


### PR DESCRIPTION
## Summary

Bump `@extrachill/tokens` from `^0.5.0` to `v0.7.2` so the deployed `assets/css/root.css` includes the `--info-color`, `--warning-color`, `--info-bg`, `--warning-bg` tokens for both light and dark mode. Paired with [Extra-Chill/extrachill-components#?](https://github.com/Extra-Chill/extrachill-components/pull/new/fix-6-info-warning-dark-mode-tokens), which swaps the hardcoded Bootstrap-era hex values in `InlineStatus` and `Badge` subtle/outline/solid variants for `var()` references to these tokens.

## Pin via git URL

`@extrachill/tokens@0.7.2` is not published to the npm registry (only `0.5.0` is). The dependency is therefore pinned via GitHub using the upstream `v0.7.2` tag:

\`\`\`json
\"@extrachill/tokens\": \"github:Extra-Chill/extrachill-tokens#v0.7.2\"
\`\`\`

`npm install && npm run build` produces a clean `assets/css/root.css` containing the new tokens — verified locally.

## Files changed

- `package.json` — single-line dependency bump.

`assets/css/root.css` and `package-lock.json` are both `.gitignored` in this repo by existing policy (root.css was added to .gitignore in commit cab0a17 \"Add build step: generate root.css from @extrachill/tokens\"). The deploy pipeline regenerates `assets/css/root.css` via `npm install && npm run build`, so this PR doesn't carry the regenerated CSS — the build step on deploy produces it.

## Token diff (v0.5.0 → v0.7.2)

New info/warning tokens emitted by v0.7.2 that were absent in v0.5.0:

**Light (`:root`):**
\`\`\`
--warning-color: #d97706;
--warning-bg:    rgba(217, 119, 6, 0.1);
--info-color:    #0b5394;
--info-bg:       rgba(11, 83, 148, 0.08);
\`\`\`

**Dark (`@media (prefers-color-scheme: dark) :root`):**
\`\`\`
--warning-color: #fbbf24;
--warning-bg:    rgba(251, 191, 36, 0.1);
--info-color:    #93c5fd;
--info-bg:       rgba(147, 197, 253, 0.08);
\`\`\`

Other token churn between v0.5.0 and v0.7.2 (bridges/refactors, etc.) is unrelated to this fix but is propagated by the bump — v0.7.2 is the current latest from `extrachill-tokens` main.

## Build verification

\`\`\`
$ npm install && npm run build
$ grep -nE 'info-color|warning-color|info-bg|warning-bg' assets/css/root.css
29:    --warning-color: #d97706;
30:    --warning-bg: rgba(217, 119, 6, 0.1);
31:    --info-color: #0b5394;
32:    --info-bg: rgba(11, 83, 148, 0.08);
590:        --warning-color: #fbbf24;
591:        --warning-bg: rgba(251, 191, 36, 0.1);
592:        --info-color: #93c5fd;
593:        --info-bg: rgba(147, 197, 253, 0.08);

$ grep -nE ':root|prefers-color-scheme' assets/css/root.css
1::root {
566:@media (prefers-color-scheme: dark) {
567:    :root {
\`\`\`

Both light AND dark selectors emit the new tokens.

## Paired with

[Extra-Chill/extrachill-components PR — InlineStatus / Badge tokens](https://github.com/Extra-Chill/extrachill-components/pull/new/fix-6-info-warning-dark-mode-tokens). Both must land + deploy for the visible dark-mode effect.

Closes Extra-Chill/extrachill-components#6 (theme side).