### PR TITLE
feat: bump @extrachill/tokens to v0.8.1 + emit theme.json at theme root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore build artifacts
 build/
 assets/css/root.css
+theme.json
 
 # Node modules (if ever added)
 node_modules/

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "2.0.12",
   "description": "Extra Chill WordPress theme",
   "scripts": {
-    "build": "cp node_modules/@extrachill/tokens/css/root.css assets/css/root.css && node scripts/build-taxonomy-badges.js"
+    "build": "cp node_modules/@extrachill/tokens/css/root.css assets/css/root.css && cp node_modules/@extrachill/tokens/css/theme.json theme.json && node scripts/build-taxonomy-badges.js"
   },
   "dependencies": {
-    "@extrachill/tokens": "github:Extra-Chill/extrachill-tokens#v0.7.2"
+    "@extrachill/tokens": "github:Extra-Chill/extrachill-tokens#v0.8.1"
   }
 }


### PR DESCRIPTION
## Summary

Bumps the `@extrachill/tokens` git dependency from **v0.7.2 → v0.8.1** and wires the new generated `theme.json` into the theme build.

- The theme `build` now copies `theme.json` to the theme root alongside `root.css`. WordPress applies `theme.json` to **classic themes** since 5.9, so core Gutenberg blocks (Cover, Columns, Group, Buttons) inherit the Extra Chill palette, spacing, font sizes/families, and content/wide widths.
- `theme.json` is gitignored as a generated build artifact, matching the existing `assets/css/root.css` convention (both produced at build/deploy time, not committed).

## Verification

- `npm install` resolves tokens v0.8.1; `npm run build` emits a valid `theme.json` at the theme root (version 3, 29 palette colors, contentSize 800px / wideSize 1600px).