### PR TITLE
feat: pillar / network-map block patterns on the tokens-driven theme.json

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -145,6 +145,7 @@ require_once EXTRACHILL_INCLUDES_DIR . '/footer/back-to-home-link.php';
 
 require_once EXTRACHILL_INCLUDES_DIR . '/core/editor/bandcamp-embeds.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/editor/instagram-embeds.php';
+require_once EXTRACHILL_INCLUDES_DIR . '/core/editor/block-patterns.php';
 
 require_once EXTRACHILL_INCLUDES_DIR . '/archives/archive-custom-sorting.php';
 

--- a/inc/core/editor/block-patterns.php
+++ b/inc/core/editor/block-patterns.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Block patterns for the Extra Chill theme.
+ *
+ * Registers an "Extra Chill" pattern category and reusable patterns built
+ * entirely from CORE blocks (Group / Columns / Heading / Paragraph / Buttons).
+ * Because the theme now ships a root theme.json (from @extrachill/tokens), these
+ * core blocks inherit the Extra Chill palette, spacing, and typography — so the
+ * patterns stay on-brand without any pattern-specific CSS.
+ *
+ * Used as the design-system foundation for the extrachill.com/power manifesto
+ * page, but intentionally generic and reusable across any page on the network.
+ *
+ * @package ExtraChill
+ * @since 1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the Extra Chill pattern category so theme patterns are discoverable
+ * in the block inserter under a single, branded group.
+ */
+function extrachill_register_block_pattern_categories() {
+	if ( ! function_exists( 'register_block_pattern_category' ) ) {
+		return;
+	}
+
+	register_block_pattern_category(
+		'extrachill',
+		array(
+			'label'       => __( 'Extra Chill', 'extrachill' ),
+			'description' => __( 'On-brand building blocks for Extra Chill pages.', 'extrachill' ),
+		)
+	);
+}
+add_action( 'init', 'extrachill_register_block_pattern_categories' );
+
+/**
+ * Register Extra Chill block patterns.
+ *
+ * All markup uses core blocks with theme.json preset classes (has-*-color,
+ * has-*-font-size, etc.) so the palette/typography come from the tokens-driven
+ * theme.json rather than inline values. This keeps the patterns in sync with the
+ * design system automatically.
+ */
+function extrachill_register_block_patterns() {
+	if ( ! function_exists( 'register_block_pattern' ) ) {
+		return;
+	}
+
+	/*
+	 * Pillar / values section.
+	 *
+	 * The reusable "values unit": heading + short statement + one clear CTA,
+	 * wrapped in a padded card Group. Drop several in a row to build a manifesto
+	 * / values page (e.g. extrachill.com/power).
+	 */
+	register_block_pattern(
+		'extrachill/pillar',
+		array(
+			'title'       => __( 'Pillar / Values Section', 'extrachill' ),
+			'description' => __( 'A single values pillar: heading, short statement, and one clear call to action. Stack several to build a manifesto or values page.', 'extrachill' ),
+			'categories'  => array( 'extrachill' ),
+			'keywords'    => array( 'pillar', 'values', 'manifesto', 'cta', 'feature' ),
+			'content'     => '<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|spacing-xl","bottom":"var:preset|spacing|spacing-xl","left":"var:preset|spacing|spacing-lg","right":"var:preset|spacing|spacing-lg"},"blockGap":"var:preset|spacing|spacing-md"}},"backgroundColor":"card-background","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-card-background-background-color has-background" style="padding-top:var(--wp--preset--spacing--spacing-xl);padding-right:var(--wp--preset--spacing--spacing-lg);padding-bottom:var(--wp--preset--spacing--spacing-xl);padding-left:var(--wp--preset--spacing--spacing-lg)"><!-- wp:heading {"level":2,"fontSize":"font-size-2xl"} -->
+<h2 class="wp-block-heading has-font-size-2xl-font-size">Pillar headline</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"font-size-body"} -->
+<p class="has-font-size-body-font-size">A short, punchy statement of what this pillar stands for. One or two sentences that make the value concrete — no fluff. Say what Extra Chill actually does here and why it matters.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"accent","textColor":"button-text-color"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-button-text-color-color has-accent-background-color has-text-color has-background wp-element-button" href="#">Learn more</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->',
+		)
+	);
+
+	/*
+	 * Network map.
+	 *
+	 * A responsive row of surface cards, each deep-linking to an Extra Chill
+	 * subsite with a one-line proof point. Reusable wherever the network needs to
+	 * be introduced (homepage, about, /power).
+	 */
+	register_block_pattern(
+		'extrachill/network-map',
+		array(
+			'title'       => __( 'Network Map', 'extrachill' ),
+			'description' => __( 'A row of surface cards linking to the Extra Chill network — Events, Community, Wire, and the Artist Platform — each with a short proof point.', 'extrachill' ),
+			'categories'  => array( 'extrachill' ),
+			'keywords'    => array( 'network', 'sites', 'map', 'surfaces', 'links' ),
+			'content'     => '<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|spacing-lg","padding":{"top":"var:preset|spacing|spacing-xl","bottom":"var:preset|spacing|spacing-xl"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--spacing-xl);padding-bottom:var(--wp--preset--spacing--spacing-xl)"><!-- wp:heading {"textAlign":"center","level":2,"fontSize":"font-size-2xl"} -->
+<h2 class="wp-block-heading has-text-align-center has-font-size-2xl-font-size">The Extra Chill Network</h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|spacing-lg","bottom":"var:preset|spacing|spacing-lg","left":"var:preset|spacing|spacing-md","right":"var:preset|spacing|spacing-md"},"blockGap":"var:preset|spacing|spacing-sm"}},"backgroundColor":"card-background"} -->
+<div class="wp-block-column has-card-background-background-color has-background" style="padding-top:var(--wp--preset--spacing--spacing-lg);padding-right:var(--wp--preset--spacing--spacing-md);padding-bottom:var(--wp--preset--spacing--spacing-lg);padding-left:var(--wp--preset--spacing--spacing-md)"><!-- wp:heading {"level":3,"fontSize":"font-size-lg"} -->
+<h3 class="wp-block-heading has-font-size-lg-font-size"><a href="https://events.extrachill.com">Events</a></h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"font-size-sm"} -->
+<p class="has-font-size-sm-font-size">Live music listings across every city we cover.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|spacing-lg","bottom":"var:preset|spacing|spacing-lg","left":"var:preset|spacing|spacing-md","right":"var:preset|spacing|spacing-md"},"blockGap":"var:preset|spacing|spacing-sm"}},"backgroundColor":"card-background"} -->
+<div class="wp-block-column has-card-background-background-color has-background" style="padding-top:var(--wp--preset--spacing--spacing-lg);padding-right:var(--wp--preset--spacing--spacing-md);padding-bottom:var(--wp--preset--spacing--spacing-lg);padding-left:var(--wp--preset--spacing--spacing-md)"><!-- wp:heading {"level":3,"fontSize":"font-size-lg"} -->
+<h3 class="wp-block-heading has-font-size-lg-font-size"><a href="https://community.extrachill.com">Community</a></h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"font-size-sm"} -->
+<p class="has-font-size-sm-font-size">Forums where fans, artists, and pros actually talk.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|spacing-lg","bottom":"var:preset|spacing|spacing-lg","left":"var:preset|spacing|spacing-md","right":"var:preset|spacing|spacing-md"},"blockGap":"var:preset|spacing|spacing-sm"}},"backgroundColor":"card-background"} -->
+<div class="wp-block-column has-card-background-background-color has-background" style="padding-top:var(--wp--preset--spacing--spacing-lg);padding-right:var(--wp--preset--spacing--spacing-md);padding-bottom:var(--wp--preset--spacing--spacing-lg);padding-left:var(--wp--preset--spacing--spacing-md)"><!-- wp:heading {"level":3,"fontSize":"font-size-lg"} -->
+<h3 class="wp-block-heading has-font-size-lg-font-size"><a href="https://wire.extrachill.com">Wire</a></h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"font-size-sm"} -->
+<p class="has-font-size-sm-font-size">News-reactive coverage from the festival circuit and beyond.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|spacing-lg","bottom":"var:preset|spacing|spacing-lg","left":"var:preset|spacing|spacing-md","right":"var:preset|spacing|spacing-md"},"blockGap":"var:preset|spacing|spacing-sm"}},"backgroundColor":"card-background"} -->
+<div class="wp-block-column has-card-background-background-color has-background" style="padding-top:var(--wp--preset--spacing--spacing-lg);padding-right:var(--wp--preset--spacing--spacing-md);padding-bottom:var(--wp--preset--spacing--spacing-lg);padding-left:var(--wp--preset--spacing--spacing-md)"><!-- wp:heading {"level":3,"fontSize":"font-size-lg"} -->
+<h3 class="wp-block-heading has-font-size-lg-font-size"><a href="https://artist.extrachill.com">Artist Platform</a></h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"font-size-sm"} -->
+<p class="has-font-size-sm-font-size">Free tools for artists to manage their career and reach fans.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->',
+		)
+	);
+}
+add_action( 'init', 'extrachill_register_block_patterns' );


### PR DESCRIPTION
## Summary

Design-system foundation for the extrachill.com/power manifesto page. Adds reusable, on-brand block patterns built from **core blocks**, now that the theme ships a tokens-driven root `theme.json`.

This PR is the **PART 2** of extrachill#35. **PART 1 (wiring `theme.json` into the theme) already landed in #36** (merged), so the diff here is just the pattern registration. Full context below.

## PART 1 — theme.json wiring (already merged in #36)

`@extrachill/tokens` v0.8.1 generates `css/theme.json` (29-color palette, 9 font sizes, 4 families, spacing scale, `contentSize: 800px` / `wideSize: 1600px`). #36 bumped the tokens dep `v0.7.2 → v0.8.1` and extended the build script to copy `theme.json` to the theme root alongside `root.css`. Verified in this branch: `npm install && npm run build` regenerates **both** `assets/css/root.css` and a valid `theme.json` (version 3, palette/spacing/typography all present) at the theme root.

### Decision: theme.json is a gitignored build artifact (NOT committed) — matching root.css

The issue text suggested committing `theme.json`. I kept it **gitignored**, consistent with the already-merged #36 and — critically — with the existing `root.css` convention. Verified facts that drove this call:

- `assets/css/root.css` is **gitignored and untracked** in the repo, yet it **is present in the deployed theme** (`/wp-content/themes/extrachill/assets/css/root.css` exists on prod). homeboy's WordPress build runs `npm run build` before packaging, so generated artifacts ship in the release zip without living in git.
- Committing `theme.json` would diverge from the `root.css` pattern and create a tracked file that silently drifts from `tokens.json` whenever the package updates but someone forgets to rebuild. Keeping it generated-at-build keeps a single source of truth (the tokens package).
- Net: same deploy outcome (theme.json ships in the release), no drift risk, one convention for all generated assets.

## PART 2 — block patterns (this PR's diff)

New file `inc/core/editor/block-patterns.php`, wired from `functions.php` next to the other `core/editor/` includes (classic-theme correct — patterns + root theme.json, **not** an FSE conversion):

- **Pattern category** `extrachill` ("Extra Chill") via `register_block_pattern_category` so theme patterns are discoverable as one branded group in the inserter.
- **`extrachill/pillar` — Pillar / Values Section**: the reusable values unit — heading + short statement + one clear CTA button, wrapped in a padded `card-background` Group. Stack several to build a manifesto/values page (e.g. /power).
- **`extrachill/network-map` — Network Map**: a responsive `Columns` row of surface cards deep-linking to Events / Community / Wire / Artist Platform, each with a one-line proof point. Reusable well beyond /power.

Both patterns use **theme.json preset classes** (`has-accent-background-color`, `has-card-background-background-color`, `has-font-size-2xl-font-size`, `var:preset|spacing|spacing-lg`, …) drawn from the real token slugs in the generated theme.json — so palette/typography/spacing come from the design system, no pattern-specific CSS, and they stay in sync as tokens evolve.

`php -l` clean on both changed PHP files; all inline block-attribute JSON validated as parseable.

## PART 3 — layout / content-width analysis (no conflict found)

A root `theme.json` with `layout.contentSize: 800px` **can** fight a theme's own content-width CSS. I inspected the theme CSS:

- The theme defines `--container-width: 1200px` (the `.extrachill-content` page wrapper holding content + sidebar) and **`--content-width: 800px`** (the reading column) in `root.css`.
- theme.json's **`contentSize: 800px` exactly matches the theme's `--content-width: 800px`** — they agree, no fight for the content column.
- theme.json layout uses low-specificity `:where()` selectors. The theme's explicit, higher-specificity alignment CSS (e.g. `body.page .entry-content > .alignfull { width:100vw; … }`, `.extrachill-content { max-width: var(--container-width) }`) **wins** wherever they overlap, so existing full-width/wide breakouts and the 1200px page wrapper are unaffected.
- `wideSize: 1600px` is wider than the 1200px page wrapper, so wide-aligned blocks are still capped by `.extrachill-content` — consistent, not broken.

**Conclusion:** no content-width conflict to resolve; `settings.layout` is left as the tokens package emits it because it already matches the theme.

### Visual-smoke recommendation (for the human, after deploy)

A root theme.json + palette can subtly change how existing pages render (core blocks inheriting widths/colors). I can't load the live site from the worktree, so please eyeball after deploy:

- Homepage
- A single post
- "The History of Extra Chill" page
- "Long Term Vision" page

Watch for: unexpected content-width changes on core blocks, color shifts on buttons/links inheriting palette presets, and that full-width/`alignfull` blocks still break out correctly.

## Verify
- `theme.json` at theme root, valid (version 3), palette/spacing/typography present — confirmed via build.
- `npm run build` regenerates both `root.css` and `theme.json` from the package — confirmed.
- Patterns register without PHP errors — `php -l` clean; block-attr JSON validated.
- No unaddressed content-width conflict (documented as intentional above).

Closes #35