### PR TITLE
fix: stop Undefined-array-key-slug warnings in theme.json font filter

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -353,6 +353,20 @@ add_filter( 'block_editor_settings_all', 'extrachill_filter_admin_only_editor_st
  * picker entry and its @font-face share a slug, with no duplicate
  * same-font-different-slug registrations.
  *
+ * Why the four families are declared INLINE here (not read from $theme_json):
+ * at the wp_theme_json_data_theme stage $theme_json->get_data() does not yet
+ * reliably contain the file-based theme.json fontFamilies — reading it returned
+ * a partial (1-family) list, and rebuilding from that partial list produced a
+ * malformed, slug-less merge. So this filter contributes all four families as
+ * fully-formed entries (each ALWAYS carrying a slug), sourced from the same
+ * slugs/values theme.json declares. It never depends on reading $data.
+ *
+ * Why version 3 (not 2): the shipped theme.json is version 3. update_with()
+ * with version 2 mixed v2/v3 fontFamily shapes during the merge, which dropped
+ * the slug key on the resulting preset entries — the direct source of the
+ * "Undefined array key 'slug'" warning in class-wp-theme-json. Matching the
+ * shipped theme.json version keeps a single coherent shape through the merge.
+ *
  * (Previous approach put @font-face inside editor-style.css with relative
  * ../fonts/ URLs — those failed to resolve because postcss-urlrebase doesn't
  * reliably rewrite paths inside @font-face src lists when CSS is inlined as a
@@ -364,72 +378,64 @@ add_filter( 'block_editor_settings_all', 'extrachill_filter_admin_only_editor_st
 function extrachill_register_theme_fonts( $theme_json ) {
 	$fonts_uri = get_template_directory_uri() . '/assets/fonts';
 
-	// Read the font-family slugs/values already declared by the shipped
-	// theme.json so this filter stays in sync with the tokens-generated source
-	// and only ADDS fontFace src to the custom fonts.
-	$data           = $theme_json->get_data();
-	$theme_families = array();
-	if ( isset( $data['settings']['typography']['fontFamilies'] ) && is_array( $data['settings']['typography']['fontFamilies'] ) ) {
-		$theme_families = $data['settings']['typography']['fontFamilies'];
-	}
-
-	// Map of theme.json slug => @font-face definition to attach. Only the two
-	// custom fonts (woff2 shipped in the theme) get a fontFace.
-	$font_faces = array(
-		'font-family-heading' => array(
-			array(
-				'fontFamily'  => 'Loft Sans',
-				'fontStyle'   => 'normal',
-				'fontWeight'  => '100 900',
-				'fontDisplay' => 'swap',
-				'src'         => array( $fonts_uri . '/WilcoLoftSans-Treble.woff2' ),
-			),
-		),
-		'font-family-brand'   => array(
-			array(
-				'fontFamily'  => 'Lobster',
-				'fontStyle'   => 'normal',
-				'fontWeight'  => '400',
-				'fontDisplay' => 'swap',
-				'src'         => array( $fonts_uri . '/Lobster2.woff2' ),
-			),
+	// @font-face definitions for the two custom fonts whose woff2 ship in the
+	// theme (assets/fonts/). Body + mono use system stacks and need no src.
+	$heading_font_face = array(
+		array(
+			'fontFamily'  => 'Loft Sans',
+			'fontStyle'   => 'normal',
+			'fontWeight'  => '100 900',
+			'fontDisplay' => 'swap',
+			'src'         => array( $fonts_uri . '/WilcoLoftSans-Treble.woff2' ),
 		),
 	);
 
-	// Rebuild the full families list, attaching fontFace to the matching slugs.
-	// Re-declaring the complete list is required because the theme.json merge
-	// replaces (not per-slug merges) the fontFamilies preset.
-	$families = array();
-	foreach ( $theme_families as $family ) {
-		if ( isset( $family['slug'] ) && isset( $font_faces[ $family['slug'] ] ) ) {
-			$family['fontFace'] = $font_faces[ $family['slug'] ];
-		}
-		$families[] = $family;
-	}
+	$brand_font_face = array(
+		array(
+			'fontFamily'  => 'Lobster',
+			'fontStyle'   => 'normal',
+			'fontWeight'  => '400',
+			'fontDisplay' => 'swap',
+			'src'         => array( $fonts_uri . '/Lobster2.woff2' ),
+		),
+	);
 
-	// Defensive fallback: if the shipped theme.json is somehow unavailable (no
-	// families read), declare the two custom fonts directly so @font-face still
-	// loads sitewide. Uses the same slugs theme.json would use.
-	if ( empty( $families ) ) {
-		$families = array(
-			array(
-				'name'       => 'Headings',
-				'slug'       => 'font-family-heading',
-				'fontFamily' => '"Loft Sans", sans-serif',
-				'fontFace'   => $font_faces['font-family-heading'],
-			),
-			array(
-				'name'       => 'Brand / logo text',
-				'slug'       => 'font-family-brand',
-				'fontFamily' => '"Lobster", sans-serif',
-				'fontFace'   => $font_faces['font-family-brand'],
-			),
-		);
-	}
+	// Declare ALL FOUR font families fully-formed, each WITH a slug, sourced
+	// from the slugs/values the shipped theme.json (version 3) declares. The
+	// theme.json merge replaces (does not per-slug merge) the fontFamilies
+	// preset, so the complete list must be re-declared here. Every entry
+	// carries a slug, so no slug-less preset is ever produced — which is what
+	// triggered the "Undefined array key 'slug'" warning.
+	$families = array(
+		array(
+			'slug'       => 'font-family-heading',
+			'name'       => 'Headings',
+			'fontFamily' => '"Loft Sans", sans-serif',
+			'fontFace'   => $heading_font_face,
+		),
+		array(
+			'slug'       => 'font-family-body',
+			'name'       => 'Body text',
+			'fontFamily' => "'Helvetica', 'Open Sans', serif",
+		),
+		array(
+			'slug'       => 'font-family-brand',
+			'name'       => 'Brand / logo text',
+			'fontFamily' => '"Lobster", sans-serif',
+			'fontFace'   => $brand_font_face,
+		),
+		array(
+			'slug'       => 'font-family-mono',
+			'name'       => 'Monospace / code',
+			'fontFamily' => "'Helvetica', Arial, sans-serif",
+		),
+	);
 
+	// Match the shipped theme.json version (3) so the merge keeps a single
+	// coherent fontFamily shape and never drops the slug key.
 	$theme_json->update_with(
 		array(
-			'version'  => 2,
+			'version'  => 3,
 			'settings' => array(
 				'typography' => array(
 					'fontFamilies' => $families,


### PR DESCRIPTION
## Summary

The `wp_theme_json_data_theme` filter `extrachill_register_theme_fonts()` in `inc/core/assets.php` was emitting 200+ `PHP Warning: Undefined array key "slug"` warnings (class-wp-theme-json-gutenberg.php lines 2301/2347) on every theme-json processing request, and the resolved `typography.fontFamilies.theme` collapsed to **1 slug-less, empty family** instead of the expected 4.

## Root cause (verified on prod)

Two compounding problems in the old filter:

1. **Filter-timing `$data` read.** The filter read `$theme_json->get_data()['settings']['typography']['fontFamilies']` at the `wp_theme_json_data_theme` stage and rebuilt the family list from it. At that stage the file-based theme.json fontFamilies are not reliably present yet — `get_data()` returned a partial (single, near-empty) entry, so the rebuild produced a malformed, slug-less list.
2. **v2/v3 version mismatch.** The shipped root `theme.json` is **version 3**, but the filter called `update_with(['version' => 2, ...])`. Mixing v2/v3 fontFamily shapes through the merge dropped the `slug` key — the direct source of the `Undefined array key "slug"` warning.

Verified on production via `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()`: resolved theme fontFamilies = **1**, slug-less, empty.

## The fix

Contribute **all four** font families inline as fully-formed entries — each **always carrying a `slug`** — sourced from the same slugs/values the shipped `theme.json` (version 3) declares:

- `font-family-heading` → `"Loft Sans", sans-serif` + `@font-face` (WilcoLoftSans-Treble.woff2)
- `font-family-body` → system stack, no fontFace
- `font-family-brand` → `"Lobster", sans-serif` + `@font-face` (Lobster2.woff2)
- `font-family-mono` → system stack, no fontFace

No reliance on reading `$data` at filter time, and `update_with` version matched to **3** so the merge keeps a single coherent shape and never drops the slug key. The two custom fonts keep their `@font-face` src (the load-bearing part) on the same slugs theme.json uses — preserving the #41 consolidation goal (no duplicate same-font-different-slug registrations).

## Verification

Exercised the real `WP_Theme_JSON_Data::update_with()` filter path against a v3 base:

```
Result count: 4
 - slug=font-family-heading name=Headings        fontFace:YES
 - slug=font-family-body    name=Body text        fontFace:no
 - slug=font-family-brand   name=Brand / logo text fontFace:YES
 - slug=font-family-mono    name=Monospace / code  fontFace:no
Slug-less entries: 0
```

- 4 families, **every one with a slug** → no slug-less preset is ever produced, so class-wp-theme-json emits zero `Undefined array key "slug"` warnings.
- Loft Sans + Lobster carry `fontFace` src → fonts still load (woff2 files present in `assets/fonts/`).
- body/mono intact (system stacks), not clobbered.
- `php -l inc/core/assets.php` clean. phpcs findings on the file are all pre-existing house-style baseline (missing doc comments elsewhere in the file); none are in the changed lines.

Closes #43