### PR TITLE
fix(archive): scope archive/search img height to post-card thumbnails (giant map pins)

### DIFF
--- a/assets/css/archive.css
+++ b/assets/css/archive.css
@@ -201,7 +201,15 @@ a.card-link-target:hover,
 }
 
 /* Archive and Search Styles (moved from style.css) */
-.archive img, .search img {
+
+/* Post-card featured thumbnails on archive + search loops. Scoped to the
+   .featured-image wrapper (rendered by inc/archives/post-card.php, which
+   extrachill-search also reuses) so the fixed card-image height never bleeds
+   onto other images that happen to sit on an archive/search page — e.g. the
+   events-map block's Leaflet emoji markers, which were being stretched to
+   260px by the previous `.archive img, .search img` selector. */
+.archive .featured-image img,
+.search .featured-image img {
 	height: 260px;
 	object-fit: cover;
 }

--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -99,6 +99,18 @@ h2.recent-title {
 	box-shadow: 0 1px 4px rgba(0,0,0,0.07);
 }
 
+/* Sidebar mini-card thumbnails own their own fixed height. Previously these
+   were sized by the over-broad `.archive img { height: 260px }` rule in
+   archive.css (the sidebar renders on archive pages via index.php). That
+   selector now only targets post-card `.featured-image img`, so the height is
+   declared here where it belongs. Matches the previous rule exactly
+   (height + object-fit only — width stays governed by the global
+   `img { max-width: 100% }`) so the minis are pixel-identical. */
+.my-recent-posts .mini-card .post-thumbnail img {
+	height: 260px;
+	object-fit: cover;
+}
+
 /* Sidebar Widget Title Contrast */
 .my-recent-posts .widget-title.sidebar-recent-title-margin {
 	background: var(--card-background);


### PR DESCRIPTION
## Summary

**Root-cause fix for the giant events-map pins.** After extrachill-events#181 switched the archive map to the block-native collapse path, qrisg/Chris saw the map's location pins rendering huge. The cause is **not** in the block or that refactor — it's this theme rule:

```css
.archive img, .search img {
	height: 260px;
	object-fit: cover;
}
```

That selector is over-broad: it sizes **every** `<img>` on any archive/search page. The events-map block's Leaflet markers are `L.divIcon`s whose 📍 emoji gets rewritten by WordPress core's emoji feature into `<img class="emoji">`. On archive pages that `<img>` was caught by `.archive img` and stretched to **260px tall** → giant pins.

## Fix

Scope the rule to the post-card `.featured-image` wrapper it was actually written for (rendered by `inc/archives/post-card.php`, which `extrachill-search` reuses via `get_template_part('inc/archives/post-card')`):

```css
.archive .featured-image img,
.search .featured-image img { height: 260px; object-fit: cover; }
```

This is an **allowlist** (positively target the card thumbnails), not a fragile blocklist of every plugin's images.

## No-regression verification

- **Post-card thumbnails (archive + search loops):** identical — same `height + object-fit`, same `.featured-image` wrapper used by both the theme loop and the search plugin's results template.
- **Sidebar recent-posts mini-cards** (`.mini-card .post-thumbnail img`): these render on archive pages via `index.php`'s `get_sidebar()` and were **also** getting their 260px from the broad rule (they had no own height). Added an explicit, identical `height: 260px; object-fit: cover` in `sidebar.css` so they stay pixel-identical.
- **Width/layout:** both new rules match the old behavior exactly (height + object-fit only); image width stays governed by the global `img { max-width: 100% }`. No layout shift.
- **Other consumers:** grepped all plugins — nothing references `.archive img` / `.search img`; the shop archive has no reliance on it. Map markers (and any other plugin images on archive/search pages) are no longer affected.
- **No `!important`** — selectors win on specificity (two classes + element).

## Related

- extrachill-events#181 (the refactor that surfaced this)
- data-machine-events: a defensive companion PR clamps the events-map block's own `.emoji-marker` size so it's bulletproof against any host theme doing this.