### PR TITLE
refactor: remove hardcoded login-register block from comments template

### DIFF
--- a/inc/single/comments.php
+++ b/inc/single/comments.php
@@ -5,7 +5,8 @@
  * Technical Implementation:
  * - Multisite author links: Uses ec_should_use_multisite_comment_links() and ec_get_comment_author_link_multisite()
  * - Native WordPress multisite authentication: Checks is_user_logged_in() for cross-site auth state
- * - Login/Register block: Renders extrachill/login-register block inline for unauthenticated users
+ * - Logged-out commenters: Shows a minimal "log in to comment" note. The login/register CTA block
+ *   is rendered by the extrachill-blog plugin via the extrachill_before_comments_template action.
  *
  * @package ExtraChill
  * @since 1.0
@@ -139,8 +140,7 @@ endif;
 			)
 		);
 	} else {
-		echo '<h3>' . __( 'Login or Register to Comment', 'extrachill' ) . '</h3>';
-		echo do_blocks( '<!-- wp:extrachill/login-register /-->' );
+		echo '<p class="comments-login-note">' . esc_html__( 'Log in to leave a comment.', 'extrachill' ) . '</p>';
 	}
 	?>
 </div><!-- #comments -->


### PR DESCRIPTION
## Summary

Removes the hardcoded `extrachill/login-register` block from the theme's single-post comments template. This **pairs with the already-merged [extrachill-blog#31](https://github.com/Extra-Chill/extrachill-blog/pull/31)**, which moved the login/register CTA into a plugin hook. These must deploy together — the plugin now renders the CTA via the `extrachill_before_comments_template` action (which fires just above the comments template, in `inc/single/single-post.php:56`), so leaving the theme's hardcoded block in place would cause the CTA to **double-render** for logged-out users.

Refs Extra-Chill/extrachill-blog#30.

## Exact lines removed

In `inc/single/comments.php` (logged-out `else` branch):

```php
} else {
	echo '<h3>' . __( 'Login or Register to Comment', 'extrachill' ) . '</h3>';
	echo do_blocks( '<!-- wp:extrachill/login-register /-->' );
}
```

## What replaces it

A minimal text affordance is kept so the comments area isn't confusing for logged-out visitors — **without** re-embedding the block:

```php
} else {
	echo '<p class="comments-login-note">' . esc_html__( 'Log in to leave a comment.', 'extrachill' ) . '</p>';
}
```

The full login/register CTA block now appears just above this section, rendered by the plugin via `extrachill_before_comments_template`. The file header docblock was updated to reflect the new ownership.

## Verification

- `php -l inc/single/comments.php` → clean (no syntax errors).
- Grep confirms **no** remaining `do_blocks( ... login-register ... )` or `wp:extrachill/login-register` anywhere in the theme.
- The theme still fires `do_action( 'extrachill_before_comments_template' )` in `inc/single/single-post.php:56`, preserving the anchor the plugin hook depends on (not touched by this PR).

---
PR only — no release/deploy, no CHANGELOG edits, no version bump.