### PR TITLE
feat: living design system page at /design-system/

### DIFF
--- a/assets/css/design-system.css
+++ b/assets/css/design-system.css
@@ -1,0 +1,434 @@
+/*
+ * Living Design System — guide layout & chrome.
+ *
+ * Layout/styling for the style guide itself. Its OWN colors, spacing and radii
+ * come from design tokens (var(--token)); no hardcoded hex/px for theme
+ * concerns and no !important (theme rule). Depends on extrachill-root for
+ * variable resolution.
+ *
+ * @package ExtraChill
+ * @since 2.7.0
+ */
+
+.ds-page {
+	max-width: var(--container-width);
+	margin: 0 auto;
+	padding: var(--spacing-xl) var(--spacing-md);
+	color: var(--text-color);
+}
+
+.ds-page__header {
+	margin-bottom: var(--spacing-xl);
+}
+
+.ds-page__title {
+	font-family: var(--font-family-brand);
+	font-size: var(--font-size-brand);
+	color: var(--text-color);
+	margin-bottom: var(--spacing-md);
+}
+
+.ds-page__intro {
+	max-width: var(--content-width);
+	font-size: var(--font-size-body);
+	line-height: var(--line-height-relaxed);
+	color: var(--muted-text);
+}
+
+.ds-page__intro code,
+.ds-page code {
+	font-family: var(--font-family-mono);
+	font-size: var(--font-size-sm);
+	background: var(--card-background);
+	padding: 0 var(--spacing-xs);
+	border-radius: var(--border-radius-sm);
+	color: var(--text-color);
+}
+
+/* === Sections === */
+.ds-section {
+	margin-bottom: var(--spacing-xl);
+	padding-bottom: var(--spacing-xl);
+	border-bottom: 1px solid var(--border-color);
+}
+
+.ds-section__title {
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-2xl);
+	color: var(--text-color);
+	margin-bottom: var(--spacing-sm);
+}
+
+.ds-section__desc {
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+	margin-bottom: var(--spacing-lg);
+}
+
+.ds-subsection__title {
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-lg);
+	color: var(--text-color);
+	margin: var(--spacing-lg) 0 var(--spacing-md);
+}
+
+/* === Color swatches === */
+.ds-swatch-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+	gap: var(--spacing-md);
+}
+
+.ds-swatch {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-md);
+	background: var(--card-background);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	padding: var(--spacing-sm);
+}
+
+.ds-swatch__chip {
+	flex-shrink: 0;
+	width: var(--spacing-xl);
+	height: var(--spacing-xl);
+	border-radius: var(--border-radius-sm);
+	border: 1px solid var(--border-color);
+}
+
+.ds-swatch__meta {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs);
+	min-width: 0;
+}
+
+.ds-swatch__token,
+.ds-typescale__token,
+.ds-font__token,
+.ds-weight__token,
+.ds-spacing__token,
+.ds-radius__token,
+.ds-tweak__control-token {
+	font-family: var(--font-family-mono);
+	font-size: var(--font-size-xs);
+	color: var(--link-color);
+	word-break: break-all;
+}
+
+.ds-swatch__label {
+	font-size: var(--font-size-sm);
+	font-weight: var(--font-weight-semibold);
+	color: var(--text-color);
+}
+
+.ds-swatch__value,
+.ds-typescale__value,
+.ds-spacing__value,
+.ds-radius__value {
+	font-family: var(--font-family-mono);
+	font-size: var(--font-size-xs);
+	color: var(--muted-text);
+}
+
+/* === Typography === */
+.ds-typescale__row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: var(--spacing-md);
+	padding: var(--spacing-sm) 0;
+	border-bottom: 1px solid var(--border-color);
+}
+
+.ds-typescale__sample {
+	font-family: var(--font-family-heading);
+	color: var(--text-color);
+	line-height: var(--line-height-tight);
+	flex: 1 1 60%;
+	min-width: 0;
+}
+
+.ds-typescale__meta {
+	display: flex;
+	align-items: baseline;
+	gap: var(--spacing-sm);
+	flex-wrap: wrap;
+}
+
+.ds-typescale__name,
+.ds-font__name,
+.ds-weight__name,
+.ds-spacing__name,
+.ds-radius__name {
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+}
+
+.ds-fonts {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+	gap: var(--spacing-md);
+}
+
+.ds-font {
+	background: var(--card-background);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	padding: var(--spacing-md);
+}
+
+.ds-font__sample {
+	display: block;
+	font-size: var(--font-size-xl);
+	color: var(--text-color);
+	margin-bottom: var(--spacing-sm);
+}
+
+.ds-font__meta {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs);
+}
+
+.ds-weights {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-lg);
+}
+
+.ds-weight {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-xs);
+}
+
+.ds-weight__sample {
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-xl);
+	color: var(--text-color);
+}
+
+/* === Spacing === */
+.ds-spacing__row {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-md);
+	padding: var(--spacing-xs) 0;
+}
+
+.ds-spacing__bar {
+	display: inline-block;
+	height: var(--spacing-md);
+	background: var(--accent);
+	border-radius: var(--border-radius-sm);
+	flex-shrink: 0;
+}
+
+/* === Radius === */
+.ds-radii {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-lg);
+}
+
+.ds-radius {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: var(--spacing-xs);
+	text-align: center;
+}
+
+.ds-radius__box {
+	width: calc(var(--spacing-xl) * 2);
+	height: calc(var(--spacing-xl) * 2);
+	background: var(--accent-2);
+	border: 1px solid var(--border-color);
+}
+
+/* === Buttons === */
+.ds-button-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--spacing-md);
+	margin-bottom: var(--spacing-md);
+}
+
+.ds-button-row__label {
+	min-width: var(--sidebar-width);
+	max-width: 100%;
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+}
+
+/* === Cards === */
+.ds-card-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	gap: var(--spacing-lg);
+}
+
+.ds-card {
+	background: var(--card-background);
+	box-shadow: var(--card-shadow);
+	border-radius: var(--border-radius-lg);
+	padding: var(--spacing-lg);
+}
+
+.ds-card__title {
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-lg);
+	color: var(--text-color);
+	margin-bottom: var(--spacing-sm);
+}
+
+.ds-card__body {
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+	margin-bottom: var(--spacing-md);
+	line-height: var(--line-height-base);
+}
+
+/* === Badges === */
+.ds-badge-wrap {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-sm);
+	margin-bottom: var(--spacing-md);
+}
+
+/* === Tweak panel === */
+.ds-tweak {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: var(--form-width);
+	max-width: 90vw;
+	overflow-y: auto;
+	background: var(--card-background);
+	border-left: 1px solid var(--border-color);
+	box-shadow: var(--card-hover-shadow);
+	padding: var(--spacing-lg);
+	z-index: 1000;
+}
+
+.ds-tweak__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--spacing-md);
+	margin-bottom: var(--spacing-sm);
+}
+
+.ds-tweak__title {
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-xl);
+	color: var(--text-color);
+}
+
+.ds-tweak__hint {
+	font-size: var(--font-size-xs);
+	color: var(--muted-text);
+	margin-bottom: var(--spacing-md);
+}
+
+.ds-tweak__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--spacing-sm);
+	margin-bottom: var(--spacing-sm);
+}
+
+.ds-tweak__feedback {
+	min-height: var(--font-size-body);
+	font-size: var(--font-size-sm);
+	color: var(--success-color);
+	margin-bottom: var(--spacing-md);
+}
+
+.ds-tweak__group {
+	margin-bottom: var(--spacing-lg);
+}
+
+.ds-tweak__group-title {
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-base);
+	color: var(--text-color);
+	margin-bottom: var(--spacing-sm);
+	padding-bottom: var(--spacing-xs);
+	border-bottom: 1px solid var(--border-color);
+}
+
+.ds-tweak__control {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	align-items: center;
+	gap: var(--spacing-sm);
+	padding: var(--spacing-xs) 0;
+}
+
+.ds-tweak__control-label {
+	font-size: var(--font-size-sm);
+	color: var(--text-color);
+}
+
+.ds-tweak__control-token {
+	grid-column: 1 / -1;
+}
+
+.ds-tweak__control input[type="color"] {
+	width: calc(var(--spacing-xl) * 1.5);
+	height: var(--spacing-xl);
+	padding: 0;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-sm);
+	background: var(--background-color);
+	cursor: pointer;
+}
+
+.ds-tweak__text {
+	width: calc(var(--spacing-xl) * 4);
+	max-width: 100%;
+	font-family: var(--font-family-mono);
+	font-size: var(--font-size-sm);
+	color: var(--text-color);
+	background: var(--background-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-sm);
+	padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+/* Toggle button floats bottom-right when the panel is closed. */
+#ds-tweak-toggle {
+	position: fixed;
+	right: var(--spacing-lg);
+	bottom: var(--spacing-lg);
+	z-index: 999;
+	box-shadow: var(--card-shadow);
+}
+
+/* Give the page body room for the panel on wide screens when open. */
+@media (min-width: 1024px) {
+	.ds-tweak-open .ds-page {
+		margin-right: var(--form-width);
+	}
+}
+
+@media (max-width: 1023px) {
+	.ds-tweak {
+		top: auto;
+		width: 100%;
+		max-width: 100%;
+		max-height: 80vh;
+		border-left: none;
+		border-top: 1px solid var(--border-color);
+	}
+
+	.ds-button-row__label {
+		min-width: 100%;
+	}
+}

--- a/assets/js/design-system.js
+++ b/assets/js/design-system.js
@@ -1,0 +1,400 @@
+/**
+ * Living Design System — tweak panel.
+ *
+ * Lets a visitor edit core-palette colors, the type scale, and border radii
+ * live. Every specimen on the page already consumes var(--token), so calling
+ * document.documentElement.style.setProperty(token, value) updates the whole
+ * page instantly.
+ *
+ * Persistence is client-side only:
+ *   - URL hash encodes the override set, so a tweaked link is shareable.
+ *   - "Copy values" copies a :root{} block to the clipboard.
+ *   - "Reset" clears overrides back to the shipped tokens.
+ *
+ * Controls initialise from the REAL shipped values by reading
+ * getComputedStyle(document.documentElement) on load, so they reflect root.css
+ * (including dark mode) rather than hardcoded defaults.
+ *
+ * @package ExtraChill
+ */
+( function () {
+	'use strict';
+
+	var HASH_PREFIX = 'ds=';
+	var root = document.documentElement;
+
+	/**
+	 * Read the live computed value of a token from :root.
+	 *
+	 * @param {string} token CSS custom property (e.g. --accent).
+	 * @return {string} Trimmed computed value.
+	 */
+	function readToken( token ) {
+		return getComputedStyle( root ).getPropertyValue( token ).trim();
+	}
+
+	/**
+	 * Normalise a CSS color to a #rrggbb hex usable by <input type="color">.
+	 * Falls back to the raw value's nearest hex via a canvas paint.
+	 *
+	 * @param {string} value Any CSS color string.
+	 * @return {string} #rrggbb (lowercase) or '#000000' on failure.
+	 */
+	function toHex( value ) {
+		if ( ! value ) {
+			return '#000000';
+		}
+
+		var v = value.trim();
+		// Already a 6-digit hex.
+		if ( /^#[0-9a-fA-F]{6}$/.test( v ) ) {
+			return v.toLowerCase();
+		}
+		// 3-digit hex -> 6-digit.
+		if ( /^#[0-9a-fA-F]{3}$/.test( v ) ) {
+			return ( '#' + v[ 1 ] + v[ 1 ] + v[ 2 ] + v[ 2 ] + v[ 3 ] + v[ 3 ] ).toLowerCase();
+		}
+
+		// Resolve any other color (rgb(), named, etc.) by painting to a canvas.
+		try {
+			var ctx = document.createElement( 'canvas' ).getContext( '2d' );
+			ctx.fillStyle = '#000000';
+			ctx.fillStyle = v;
+			var resolved = ctx.fillStyle;
+			if ( /^#[0-9a-fA-F]{6}$/.test( resolved ) ) {
+				return resolved.toLowerCase();
+			}
+			// ctx may return rgb(...) — convert.
+			var m = resolved.match( /rgba?\((\d+),\s*(\d+),\s*(\d+)/ );
+			if ( m ) {
+				return (
+					'#' +
+					[ m[ 1 ], m[ 2 ], m[ 3 ] ]
+						.map( function ( n ) {
+							var h = parseInt( n, 10 ).toString( 16 );
+							return h.length === 1 ? '0' + h : h;
+						} )
+						.join( '' )
+				);
+			}
+		} catch ( e ) {
+			// Ignore — fall through to default.
+		}
+
+		return '#000000';
+	}
+
+	/**
+	 * Apply an override to :root and update any matching computed-value labels.
+	 *
+	 * @param {string} token CSS custom property.
+	 * @param {string} value New value.
+	 */
+	function applyOverride( token, value ) {
+		root.style.setProperty( token, value );
+		refreshComputedLabels( token );
+	}
+
+	/**
+	 * Collect the current override set (only tokens we actually changed).
+	 *
+	 * @return {Object} token -> value map.
+	 */
+	function collectOverrides() {
+		var overrides = {};
+		var controls = document.querySelectorAll( '[data-ds-token]' );
+		controls.forEach( function ( el ) {
+			var token = el.getAttribute( 'data-ds-token' );
+			var inline = root.style.getPropertyValue( token ).trim();
+			if ( inline ) {
+				overrides[ token ] = inline;
+			}
+		} );
+		return overrides;
+	}
+
+	/**
+	 * Update the on-page computed-value labels (data-ds-computed) for a token,
+	 * or all of them when no token is given.
+	 *
+	 * @param {string} [onlyToken] Limit refresh to a single token.
+	 */
+	function refreshComputedLabels( onlyToken ) {
+		var labels = document.querySelectorAll( '[data-ds-computed]' );
+		labels.forEach( function ( el ) {
+			var token = el.getAttribute( 'data-ds-computed' );
+			if ( onlyToken && token !== onlyToken ) {
+				return;
+			}
+			el.textContent = readToken( token );
+		} );
+	}
+
+	/**
+	 * Initialise every control from the live computed value.
+	 */
+	function initControls() {
+		document.querySelectorAll( '[data-ds-control]' ).forEach( function ( input ) {
+			var token = input.getAttribute( 'data-ds-token' );
+			var type = input.getAttribute( 'data-ds-control' );
+			var current = readToken( token );
+
+			if ( type === 'color' ) {
+				input.value = toHex( current );
+			} else {
+				input.value = current;
+			}
+
+			input.addEventListener( 'input', function () {
+				applyOverride( token, input.value );
+				writeHash();
+			} );
+		} );
+	}
+
+	/**
+	 * Serialize overrides into the URL hash (shareable as-is).
+	 */
+	function writeHash() {
+		var overrides = collectOverrides();
+		var keys = Object.keys( overrides );
+		if ( ! keys.length ) {
+			// Clear hash without adding a history entry.
+			history.replaceState( null, '', window.location.pathname + window.location.search );
+			return;
+		}
+		var encoded = encodeURIComponent( JSON.stringify( overrides ) );
+		history.replaceState( null, '', '#' + HASH_PREFIX + encoded );
+	}
+
+	/**
+	 * Read overrides from the URL hash and apply them on load.
+	 */
+	function applyHash() {
+		var hash = window.location.hash.replace( /^#/, '' );
+		if ( hash.indexOf( HASH_PREFIX ) !== 0 ) {
+			return;
+		}
+		var raw = hash.slice( HASH_PREFIX.length );
+		var overrides;
+		try {
+			overrides = JSON.parse( decodeURIComponent( raw ) );
+		} catch ( e ) {
+			return;
+		}
+		if ( ! overrides || typeof overrides !== 'object' ) {
+			return;
+		}
+
+		Object.keys( overrides ).forEach( function ( token ) {
+			applyOverride( token, overrides[ token ] );
+		} );
+
+		// Sync the controls to the applied overrides.
+		document.querySelectorAll( '[data-ds-control]' ).forEach( function ( input ) {
+			var token = input.getAttribute( 'data-ds-token' );
+			if ( ! ( token in overrides ) ) {
+				return;
+			}
+			if ( input.getAttribute( 'data-ds-control' ) === 'color' ) {
+				input.value = toHex( overrides[ token ] );
+			} else {
+				input.value = overrides[ token ];
+			}
+		} );
+	}
+
+	/**
+	 * Build a CSS :root{} block from the current overrides.
+	 *
+	 * @return {string} CSS text, or a comment when there are no overrides.
+	 */
+	function buildCssBlock() {
+		var overrides = collectOverrides();
+		var keys = Object.keys( overrides );
+		if ( ! keys.length ) {
+			return '/* No token overrides — page reflects shipped @extrachill/tokens. */';
+		}
+		var lines = keys.map( function ( token ) {
+			return '  ' + token + ': ' + overrides[ token ] + ';';
+		} );
+		return ':root {\n' + lines.join( '\n' ) + '\n}';
+	}
+
+	/**
+	 * Copy text to the clipboard with a graceful fallback.
+	 *
+	 * @param {string} text Text to copy.
+	 * @return {Promise}
+	 */
+	function copyText( text ) {
+		if ( navigator.clipboard && navigator.clipboard.writeText ) {
+			return navigator.clipboard.writeText( text );
+		}
+		return new Promise( function ( resolve, reject ) {
+			try {
+				var ta = document.createElement( 'textarea' );
+				ta.value = text;
+				ta.setAttribute( 'readonly', '' );
+				ta.style.position = 'absolute';
+				ta.style.left = '-9999px';
+				document.body.appendChild( ta );
+				ta.select();
+				document.execCommand( 'copy' );
+				document.body.removeChild( ta );
+				resolve();
+			} catch ( e ) {
+				reject( e );
+			}
+		} );
+	}
+
+	/**
+	 * Show a transient feedback message in the panel.
+	 *
+	 * @param {string} message Text to display.
+	 */
+	function feedback( message ) {
+		var el = document.querySelector( '[data-ds-feedback]' );
+		if ( ! el ) {
+			return;
+		}
+		el.textContent = message;
+		window.clearTimeout( feedback._t );
+		feedback._t = window.setTimeout( function () {
+			el.textContent = '';
+		}, 2500 );
+	}
+
+	/**
+	 * Reset all overrides back to the shipped tokens.
+	 */
+	function resetOverrides() {
+		document.querySelectorAll( '[data-ds-token]' ).forEach( function ( el ) {
+			var token = el.getAttribute( 'data-ds-token' );
+			root.style.removeProperty( token );
+		} );
+		initControls(); // Re-read shipped computed values into the controls.
+		refreshComputedLabels();
+		writeHash();
+		feedback( 'Reset to shipped tokens.' );
+	}
+
+	/**
+	 * Toggle the tweak panel open/closed.
+	 */
+	function togglePanel() {
+		var panel = document.getElementById( 'ds-tweak-panel' );
+		var toggle = document.getElementById( 'ds-tweak-toggle' );
+		if ( ! panel ) {
+			return;
+		}
+		var willShow = panel.hasAttribute( 'hidden' );
+		if ( willShow ) {
+			panel.removeAttribute( 'hidden' );
+			document.body.classList.add( 'ds-tweak-open' );
+		} else {
+			panel.setAttribute( 'hidden', '' );
+			document.body.classList.remove( 'ds-tweak-open' );
+		}
+		if ( toggle ) {
+			toggle.setAttribute( 'aria-expanded', String( willShow ) );
+		}
+		panel.querySelectorAll( '[data-ds-action="toggle"]' ).forEach( function ( btn ) {
+			btn.setAttribute( 'aria-expanded', String( willShow ) );
+		} );
+	}
+
+	/**
+	 * Wire the action buttons (copy / share / reset / toggle).
+	 */
+	function initActions() {
+		document.querySelectorAll( '[data-ds-action]' ).forEach( function ( btn ) {
+			var action = btn.getAttribute( 'data-ds-action' );
+			btn.addEventListener( 'click', function () {
+				if ( action === 'copy' ) {
+					copyText( buildCssBlock() ).then(
+						function () {
+							feedback( 'Copied token values.' );
+						},
+						function () {
+							feedback( 'Copy failed — select and copy manually.' );
+						}
+					);
+				} else if ( action === 'share' ) {
+					writeHash();
+					copyText( window.location.href ).then(
+						function () {
+							feedback( 'Copied shareable link.' );
+						},
+						function () {
+							feedback( 'Copy failed — copy the URL manually.' );
+						}
+					);
+				} else if ( action === 'reset' ) {
+					resetOverrides();
+				} else if ( action === 'toggle' ) {
+					togglePanel();
+				}
+			} );
+		} );
+	}
+
+	/**
+	 * Reveal the panel + toggle (hidden by default so the page is usable
+	 * without JS) and boot everything.
+	 */
+	function boot() {
+		var panel = document.getElementById( 'ds-tweak-panel' );
+		var toggle = document.getElementById( 'ds-tweak-toggle' );
+
+		refreshComputedLabels();
+		initControls();
+		initActions();
+		applyHash();
+		refreshComputedLabels();
+
+		// Reveal the controls now that JS is active.
+		if ( toggle ) {
+			toggle.removeAttribute( 'hidden' );
+		}
+		if ( panel ) {
+			// Open the panel by default on wide viewports, collapsed on narrow.
+			if ( window.matchMedia( '(min-width: 1024px)' ).matches ) {
+				panel.removeAttribute( 'hidden' );
+				document.body.classList.add( 'ds-tweak-open' );
+				if ( toggle ) {
+					toggle.setAttribute( 'aria-expanded', 'true' );
+				}
+			}
+		}
+
+		// Keep specimens in sync if the OS color scheme flips while open.
+		if ( window.matchMedia ) {
+			window
+				.matchMedia( '(prefers-color-scheme: dark)' )
+				.addEventListener( 'change', function () {
+					// Only refresh controls/labels for tokens without overrides.
+					var overrides = collectOverrides();
+					document.querySelectorAll( '[data-ds-control]' ).forEach( function ( input ) {
+						var token = input.getAttribute( 'data-ds-token' );
+						if ( token in overrides ) {
+							return;
+						}
+						var current = readToken( token );
+						input.value =
+							input.getAttribute( 'data-ds-control' ) === 'color'
+								? toHex( current )
+								: current;
+					} );
+					refreshComputedLabels();
+				} );
+		}
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', boot );
+	} else {
+		boot();
+	}
+} )();

--- a/functions.php
+++ b/functions.php
@@ -134,6 +134,7 @@ require_once EXTRACHILL_INCLUDES_DIR . '/core/notices.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/rewrite.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/site-title.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/template-router.php';
+require_once EXTRACHILL_INCLUDES_DIR . '/core/design-system.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/templates/breadcrumbs.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/header/header-search.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/custom-taxonomies.php';

--- a/inc/core/design-system.php
+++ b/inc/core/design-system.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Living Design System Page
+ *
+ * Registers a public (unlisted, noindexed) route at /design-system/ that
+ * renders a living style guide for the Extra Chill theme. Every specimen on
+ * the page consumes live CSS custom properties from assets/css/root.css, and a
+ * client-side tweak panel lets visitors edit tokens and watch the page shift.
+ *
+ * The route is wired with a dedicated rewrite rule + query var so it works
+ * regardless of any page or post that might otherwise claim the slug. The
+ * template is swapped via template_include at priority 5 — ahead of the main
+ * router at priority 10 — and the request is forced to a 200 (is_404 = false).
+ *
+ * Persistence for tweaks is client-side only (URL hash + clipboard export);
+ * nothing is ever written to the server. The source of truth for tokens
+ * remains the @extrachill/tokens package.
+ *
+ * @package ExtraChill
+ * @since 2.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Query var that flags a request as the design-system route.
+ */
+const EXTRACHILL_DESIGN_SYSTEM_QUERY_VAR = 'extrachill_design_system';
+
+/**
+ * Option flag used to flush rewrite rules exactly once after this feature ships.
+ */
+const EXTRACHILL_DESIGN_SYSTEM_FLUSH_FLAG = 'extrachill_design_system_rewrite_flushed';
+
+/**
+ * Register the rewrite rule mapping /design-system/ to the query var.
+ */
+function extrachill_design_system_rewrite_rule() {
+	add_rewrite_rule(
+		'^design-system/?$',
+		'index.php?' . EXTRACHILL_DESIGN_SYSTEM_QUERY_VAR . '=1',
+		'top'
+	);
+}
+add_action( 'init', 'extrachill_design_system_rewrite_rule' );
+
+/**
+ * Whitelist the design-system query var so WordPress preserves it.
+ *
+ * @param array $vars Registered public query vars.
+ * @return array
+ */
+function extrachill_design_system_query_var( $vars ) {
+	$vars[] = EXTRACHILL_DESIGN_SYSTEM_QUERY_VAR;
+	return $vars;
+}
+add_filter( 'query_vars', 'extrachill_design_system_query_var' );
+
+/**
+ * Flush rewrite rules exactly once so the new rule resolves after deploy.
+ *
+ * Runs on init (after the rule is registered) and self-disables via an option
+ * flag, so it never repeats on subsequent requests.
+ */
+function extrachill_design_system_maybe_flush_rewrite() {
+	if ( get_option( EXTRACHILL_DESIGN_SYSTEM_FLUSH_FLAG ) ) {
+		return;
+	}
+
+	flush_rewrite_rules( false );
+	update_option( EXTRACHILL_DESIGN_SYSTEM_FLUSH_FLAG, 1 );
+}
+add_action( 'init', 'extrachill_design_system_maybe_flush_rewrite', 20 );
+
+/**
+ * Whether the current request is the design-system route.
+ *
+ * @return bool
+ */
+function extrachill_is_design_system() {
+	return (bool) get_query_var( EXTRACHILL_DESIGN_SYSTEM_QUERY_VAR );
+}
+
+/**
+ * Force a 200 status for the design-system route.
+ *
+ * Without this, WordPress would resolve the unknown URL to a 404 since no post
+ * or page backs it.
+ */
+function extrachill_design_system_force_200() {
+	if ( ! extrachill_is_design_system() ) {
+		return;
+	}
+
+	global $wp_query;
+	$wp_query->is_404 = false;
+	status_header( 200 );
+}
+add_action( 'template_redirect', 'extrachill_design_system_force_200' );
+
+/**
+ * Swap in the design-system template ahead of the main template router.
+ *
+ * Priority 5 runs before the theme's template-router (priority 10), so the
+ * router's is_404() fallback never fires for this route.
+ *
+ * @param string $template Default template path.
+ * @return string
+ */
+function extrachill_design_system_template( $template ) {
+	if ( ! extrachill_is_design_system() ) {
+		return $template;
+	}
+
+	$candidate = get_template_directory() . '/inc/core/templates/design-system.php';
+	if ( file_exists( $candidate ) ) {
+		return $candidate;
+	}
+
+	return $template;
+}
+add_filter( 'template_include', 'extrachill_design_system_template', 5 );
+
+/**
+ * Emit a noindex meta tag so the unlisted page stays out of search engines.
+ */
+function extrachill_design_system_noindex() {
+	if ( ! extrachill_is_design_system() ) {
+		return;
+	}
+
+	echo '<meta name="robots" content="noindex, nofollow" />' . "\n";
+}
+add_action( 'wp_head', 'extrachill_design_system_noindex', 1 );
+
+/**
+ * Enqueue the design-system assets only on the design-system route.
+ *
+ * root.css (extrachill-root), taxonomy-badges.css and style.css are already
+ * enqueued globally by inc/core/assets.php, but taxonomy-badges.css is normally
+ * deferred (media="print" swap) — here we ensure it loads eagerly so the badge
+ * specimens render correctly on first paint. The guide's own layout CSS and the
+ * tweak-panel JS are enqueued conditionally with filemtime() versioning.
+ */
+function extrachill_design_system_assets() {
+	if ( ! extrachill_is_design_system() ) {
+		return;
+	}
+
+	// Ensure root tokens are present (dependency for everything below).
+	$root_css_path = get_stylesheet_directory() . '/assets/css/root.css';
+	if ( file_exists( $root_css_path ) && ! wp_style_is( 'extrachill-root', 'enqueued' ) ) {
+		wp_enqueue_style(
+			'extrachill-root',
+			get_stylesheet_directory_uri() . '/assets/css/root.css',
+			array(),
+			filemtime( $root_css_path )
+		);
+	}
+
+	// Eager copy of the badge colors under a dedicated handle so the live badge
+	// specimens are correct on first paint (the global handle is deferred).
+	$badges_css_path = get_stylesheet_directory() . '/assets/css/taxonomy-badges.css';
+	if ( file_exists( $badges_css_path ) ) {
+		wp_enqueue_style(
+			'extrachill-design-system-badges',
+			get_stylesheet_directory_uri() . '/assets/css/taxonomy-badges.css',
+			array( 'extrachill-root' ),
+			filemtime( $badges_css_path )
+		);
+	}
+
+	// Guide layout/chrome CSS.
+	$guide_css_path = get_stylesheet_directory() . '/assets/css/design-system.css';
+	if ( file_exists( $guide_css_path ) ) {
+		wp_enqueue_style(
+			'extrachill-design-system',
+			get_stylesheet_directory_uri() . '/assets/css/design-system.css',
+			array( 'extrachill-root', 'extrachill-style' ),
+			filemtime( $guide_css_path )
+		);
+	}
+
+	// Tweak-panel logic.
+	$guide_js_path = get_stylesheet_directory() . '/assets/js/design-system.js';
+	if ( file_exists( $guide_js_path ) ) {
+		wp_enqueue_script(
+			'extrachill-design-system',
+			get_stylesheet_directory_uri() . '/assets/js/design-system.js',
+			array(),
+			filemtime( $guide_js_path ),
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+			)
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_design_system_assets', 30 );

--- a/inc/core/templates/design-system.php
+++ b/inc/core/templates/design-system.php
@@ -1,0 +1,440 @@
+<?php
+/**
+ * Living Design System Template
+ *
+ * A public, unlisted, noindexed style guide for the Extra Chill theme. Every
+ * specimen consumes live CSS custom properties (var(--token)) so the page
+ * always reflects whatever the shipped tokens currently are, including the
+ * dark-mode overrides in root.css.
+ *
+ * A client-side tweak panel (assets/js/design-system.js) lets visitors edit
+ * the core palette, type scale and radii live, copy the override set, share via
+ * URL hash, and reset. Nothing is ever written to the server — the source of
+ * truth for tokens stays the @extrachill/tokens package.
+ *
+ * Loaded via template_include (priority 5) in inc/core/design-system.php.
+ *
+ * @package ExtraChill
+ * @since 2.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Specimen data. Token names ONLY — no hardcoded colors or sizes. Every value
+ * is rendered through var(--token) and the live computed value is filled in by
+ * JS reading getComputedStyle() on load.
+ * ---------------------------------------------------------------------------
+ */
+
+// Core palette colors — these are editable in the tweak panel.
+$ds_palette_colors = array(
+	'--background-color'  => 'Background',
+	'--text-color'        => 'Text',
+	'--link-color'        => 'Link',
+	'--link-color-hover'  => 'Link Hover',
+	'--border-color'      => 'Border',
+	'--accent'            => 'Accent',
+	'--accent-hover'      => 'Accent Hover',
+	'--accent-2'          => 'Accent 2',
+	'--accent-3'          => 'Accent 3',
+	'--error-color'       => 'Error',
+	'--success-color'     => 'Success',
+	'--warning-color'     => 'Warning',
+	'--info-color'        => 'Info',
+	'--muted-text'        => 'Muted Text',
+	'--card-background'   => 'Card Background',
+	'--button-text-color' => 'Button Text',
+);
+
+// Identity badge colors — shown as swatches (not editable in v1).
+$ds_identity_colors = array(
+	'--artist-badge-color'       => 'Artist',
+	'--team-badge-color'         => 'Team',
+	'--professional-badge-color' => 'Professional',
+);
+
+// Type scale — editable (number + unit) in the tweak panel.
+$ds_font_sizes = array(
+	'--font-size-xs'    => 'xs',
+	'--font-size-sm'    => 'sm',
+	'--font-size-base'  => 'base',
+	'--font-size-body'  => 'body',
+	'--font-size-lg'    => 'lg',
+	'--font-size-xl'    => 'xl',
+	'--font-size-2xl'   => '2xl',
+	'--font-size-3xl'   => '3xl',
+	'--font-size-brand' => 'brand',
+);
+
+// Font families.
+$ds_font_families = array(
+	'--font-family-heading' => 'Heading (Loft Sans)',
+	'--font-family-body'    => 'Body',
+	'--font-family-brand'   => 'Brand (Lobster)',
+	'--font-family-mono'    => 'Mono',
+);
+
+// Font weights.
+$ds_font_weights = array(
+	'--font-weight-normal'   => 'Normal',
+	'--font-weight-medium'   => 'Medium',
+	'--font-weight-semibold' => 'Semibold',
+	'--font-weight-bold'     => 'Bold',
+);
+
+// Spacing scale — shown as bars, NOT editable.
+$ds_spacing = array(
+	'--spacing-xs' => 'xs',
+	'--spacing-sm' => 'sm',
+	'--spacing-md' => 'md',
+	'--spacing-lg' => 'lg',
+	'--spacing-xl' => 'xl',
+);
+
+// Border radii — editable (number + unit) in the tweak panel.
+$ds_radii = array(
+	'--border-radius-sm'     => 'sm',
+	'--border-radius-md'     => 'md',
+	'--border-radius-lg'     => 'lg',
+	'--border-radius-xl'     => 'xl',
+	'--border-radius-pill'   => 'pill',
+	'--border-radius-circle' => 'circle',
+);
+
+// Representative real badge specimens. Each entry: [css-class, label].
+$ds_festival_badges = array(
+	array( 'festival-bonnaroo', 'Bonnaroo' ),
+	array( 'festival-coachella', 'Coachella' ),
+	array( 'festival-acl-festival', 'ACL Festival' ),
+	array( 'festival-sxsw', 'SXSW' ),
+	array( 'festival-electric-forest', 'Electric Forest' ),
+	array( 'festival-hulaween', 'Hulaween' ),
+	array( 'festival-shaky-knees', 'Shaky Knees' ),
+	array( 'festival-governors-ball', 'Governors Ball' ),
+	array( 'festival-lollapalooza', 'Lollapalooza' ),
+	array( 'festival-outside-lands', 'Outside Lands' ),
+	array( 'festival-riot-fest', 'Riot Fest' ),
+	array( 'festival-hopscotch-festival', 'Hopscotch' ),
+);
+
+$ds_location_badges = array(
+	array( 'location-charleston', 'Charleston' ),
+	array( 'location-austin', 'Austin' ),
+	array( 'location-asheville', 'Asheville' ),
+	array( 'location-nashville', 'Nashville' ),
+	array( 'location-new-orleans', 'New Orleans' ),
+	array( 'location-chicago', 'Chicago' ),
+	array( 'location-atlanta', 'Atlanta' ),
+	array( 'location-brooklyn', 'Brooklyn' ),
+	array( 'location-denver', 'Denver' ),
+	array( 'location-seattle', 'Seattle' ),
+	array( 'location-savannah', 'Savannah' ),
+	array( 'location-columbia', 'Columbia' ),
+);
+
+$ds_venue_badges = array(
+	array( 'venue-the-royal-american', 'The Royal American' ),
+	array( 'venue-the-bounty-bar', 'The Bounty Bar' ),
+	array( 'venue-the-refinery', 'The Refinery' ),
+	array( 'venue-lo-fi-brewing', 'Lo-Fi Brewing' ),
+	array( 'venue-charleston-tin-roof', 'Charleston Tin Roof' ),
+);
+
+$ds_artist_badges = array(
+	array( 'artist-susto', 'SUSTO' ),
+);
+
+// Category badges follow the `category-{slug}-badge` convention.
+$ds_category_badges = array(
+	array( 'category-interviews-badge', 'Interviews' ),
+	array( 'category-concerts-badge', 'Concerts' ),
+	array( 'category-festivals-badge', 'Festivals' ),
+	array( 'category-music-news-badge', 'Music News' ),
+	array( 'category-song-meanings-badge', 'Song Meanings' ),
+	array( 'category-festival-news-badge', 'Festival News' ),
+);
+
+/**
+ * Render a color swatch that consumes a live token.
+ *
+ * @param string $token CSS custom property name (e.g. --accent).
+ * @param string $label Human label.
+ */
+function extrachill_ds_color_swatch( $token, $label ) {
+	printf(
+		'<div class="ds-swatch" data-ds-color-token="%1$s">' .
+			'<span class="ds-swatch__chip" style="background:var(%1$s);"></span>' .
+			'<span class="ds-swatch__meta">' .
+				'<code class="ds-swatch__token">%1$s</code>' .
+				'<span class="ds-swatch__label">%2$s</span>' .
+				'<code class="ds-swatch__value" data-ds-computed="%1$s">—</code>' .
+			'</span>' .
+		'</div>',
+		esc_attr( $token ),
+		esc_html( $label )
+	);
+}
+
+get_header(); ?>
+
+<?php do_action( 'extrachill_before_body_content' ); ?>
+
+<article id="design-system" class="ds-page">
+
+	<header class="ds-page__header">
+		<h1 class="ds-page__title">Extra Chill Design System</h1>
+		<p class="ds-page__intro">
+			A <strong>living style guide</strong> for the Extra Chill theme. Every specimen below
+			consumes the live design tokens shipped in <code>root.css</code> (including dark-mode
+			overrides). Use the tweak panel to propose changes — edits are <strong>local to your
+			browser only</strong>, never saved to the server. The source of truth for tokens is the
+			<code>@extrachill/tokens</code> package. Copy or share a tweaked link to send a
+			recommended palette back to the team.
+		</p>
+	</header>
+
+	<!-- ===================== TOKENS ===================== -->
+	<section class="ds-section" id="ds-colors">
+		<h2 class="ds-section__title">Colors</h2>
+		<p class="ds-section__desc">Core palette. Each swatch shows the token name and its live computed value.</p>
+		<div class="ds-swatch-grid">
+			<?php foreach ( $ds_palette_colors as $token => $label ) : ?>
+				<?php extrachill_ds_color_swatch( $token, $label ); ?>
+			<?php endforeach; ?>
+		</div>
+
+		<h3 class="ds-subsection__title">Identity Badge Colors</h3>
+		<div class="ds-swatch-grid">
+			<?php foreach ( $ds_identity_colors as $token => $label ) : ?>
+				<?php extrachill_ds_color_swatch( $token, $label ); ?>
+			<?php endforeach; ?>
+		</div>
+	</section>
+
+	<section class="ds-section" id="ds-typography">
+		<h2 class="ds-section__title">Typography</h2>
+
+		<h3 class="ds-subsection__title">Type Scale</h3>
+		<div class="ds-typescale">
+			<?php foreach ( $ds_font_sizes as $token => $label ) : ?>
+				<div class="ds-typescale__row">
+					<span class="ds-typescale__sample" style="font-size:var(<?php echo esc_attr( $token ); ?>);">
+						Extra Chill — the Online Music Scene
+					</span>
+					<span class="ds-typescale__meta">
+						<code class="ds-typescale__token"><?php echo esc_html( $token ); ?></code>
+						<span class="ds-typescale__name"><?php echo esc_html( $label ); ?></span>
+						<code class="ds-typescale__value" data-ds-computed="<?php echo esc_attr( $token ); ?>">—</code>
+					</span>
+				</div>
+			<?php endforeach; ?>
+		</div>
+
+		<h3 class="ds-subsection__title">Font Families</h3>
+		<div class="ds-fonts">
+			<?php foreach ( $ds_font_families as $token => $label ) : ?>
+				<div class="ds-font" style="font-family:var(<?php echo esc_attr( $token ); ?>);">
+					<span class="ds-font__sample">Aa Bb Cc — Extra Chill 2026</span>
+					<span class="ds-font__meta">
+						<code class="ds-font__token"><?php echo esc_html( $token ); ?></code>
+						<span class="ds-font__name"><?php echo esc_html( $label ); ?></span>
+					</span>
+				</div>
+			<?php endforeach; ?>
+		</div>
+
+		<h3 class="ds-subsection__title">Font Weights</h3>
+		<div class="ds-weights">
+			<?php foreach ( $ds_font_weights as $token => $label ) : ?>
+				<div class="ds-weight" style="font-weight:var(<?php echo esc_attr( $token ); ?>);">
+					<span class="ds-weight__sample">Extra Chill</span>
+					<code class="ds-weight__token"><?php echo esc_html( $token ); ?></code>
+					<span class="ds-weight__name"><?php echo esc_html( $label ); ?></span>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	</section>
+
+	<section class="ds-section" id="ds-spacing">
+		<h2 class="ds-section__title">Spacing</h2>
+		<p class="ds-section__desc">Display only — spacing is shown but not editable in v1.</p>
+		<div class="ds-spacing">
+			<?php foreach ( $ds_spacing as $token => $label ) : ?>
+				<div class="ds-spacing__row">
+					<span class="ds-spacing__bar" style="width:var(<?php echo esc_attr( $token ); ?>);"></span>
+					<code class="ds-spacing__token"><?php echo esc_html( $token ); ?></code>
+					<span class="ds-spacing__name"><?php echo esc_html( $label ); ?></span>
+					<code class="ds-spacing__value" data-ds-computed="<?php echo esc_attr( $token ); ?>">—</code>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	</section>
+
+	<section class="ds-section" id="ds-radius">
+		<h2 class="ds-section__title">Border Radius</h2>
+		<div class="ds-radii">
+			<?php foreach ( $ds_radii as $token => $label ) : ?>
+				<div class="ds-radius">
+					<span class="ds-radius__box" style="border-radius:var(<?php echo esc_attr( $token ); ?>);"></span>
+					<code class="ds-radius__token"><?php echo esc_html( $token ); ?></code>
+					<span class="ds-radius__name"><?php echo esc_html( $label ); ?></span>
+					<code class="ds-radius__value" data-ds-computed="<?php echo esc_attr( $token ); ?>">—</code>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	</section>
+
+	<!-- ===================== COMPONENTS ===================== -->
+	<section class="ds-section" id="ds-buttons">
+		<h2 class="ds-section__title">Buttons</h2>
+		<p class="ds-section__desc">Real theme button classes, in all three sizes.</p>
+		<?php
+		$ds_button_variants = array(
+			'button-1'      => 'Primary',
+			'button-2'      => 'Accent',
+			'button-3'      => 'Subtle',
+			'button-danger' => 'Danger',
+		);
+		$ds_button_sizes    = array( 'button-small', 'button-medium', 'button-large' );
+		?>
+		<?php foreach ( $ds_button_variants as $variant => $variant_label ) : ?>
+			<div class="ds-button-row">
+				<span class="ds-button-row__label"><?php echo esc_html( $variant_label ); ?> <code>.<?php echo esc_html( $variant ); ?></code></span>
+				<?php foreach ( $ds_button_sizes as $size ) : ?>
+					<button type="button" class="<?php echo esc_attr( $variant . ' ' . $size ); ?>"><?php echo esc_html( ucfirst( str_replace( 'button-', '', $size ) ) ); ?></button>
+				<?php endforeach; ?>
+			</div>
+		<?php endforeach; ?>
+	</section>
+
+	<section class="ds-section" id="ds-notices">
+		<h2 class="ds-section__title">Notices</h2>
+		<div class="notice notice-success">Success — the three-tier notice system.</div>
+		<div class="notice notice-info">Info — neutral informational message.</div>
+		<div class="notice notice-error">Error — something needs attention.</div>
+	</section>
+
+	<section class="ds-section" id="ds-cards">
+		<h2 class="ds-section__title">Cards</h2>
+		<div class="ds-card-grid">
+			<div class="ds-card">
+				<h3 class="ds-card__title">Card Specimen</h3>
+				<p class="ds-card__body">
+					Uses <code>--card-background</code>, <code>--card-shadow</code> and
+					<code>--border-radius-lg</code>. Edit those tokens in the tweak panel and watch
+					this card shift.
+				</p>
+				<button type="button" class="button-2 button-small">Action</button>
+			</div>
+			<div class="ds-card">
+				<h3 class="ds-card__title">Another Card</h3>
+				<p class="ds-card__body">
+					Cards are a network-wide convention. The chrome here is built entirely from
+					tokens — no hardcoded colors or sizes.
+				</p>
+				<button type="button" class="button-3 button-small">Secondary</button>
+			</div>
+		</div>
+	</section>
+
+	<section class="ds-section" id="ds-badges">
+		<h2 class="ds-section__title">Taxonomy Badges</h2>
+		<p class="ds-section__desc">Real badge classes from <code>taxonomy-badges.css</code>, colored by live <code>--badge-*</code> tokens.</p>
+
+		<h3 class="ds-subsection__title">Festivals</h3>
+		<div class="ds-badge-wrap">
+			<?php foreach ( $ds_festival_badges as $badge ) : ?>
+				<span class="taxonomy-badge <?php echo esc_attr( $badge[0] ); ?>"><?php echo esc_html( $badge[1] ); ?></span>
+			<?php endforeach; ?>
+		</div>
+
+		<h3 class="ds-subsection__title">Locations</h3>
+		<div class="ds-badge-wrap">
+			<?php foreach ( $ds_location_badges as $badge ) : ?>
+				<span class="taxonomy-badge <?php echo esc_attr( $badge[0] ); ?>"><?php echo esc_html( $badge[1] ); ?></span>
+			<?php endforeach; ?>
+		</div>
+
+		<h3 class="ds-subsection__title">Venues</h3>
+		<div class="ds-badge-wrap">
+			<?php foreach ( $ds_venue_badges as $badge ) : ?>
+				<span class="taxonomy-badge <?php echo esc_attr( $badge[0] ); ?>"><?php echo esc_html( $badge[1] ); ?></span>
+			<?php endforeach; ?>
+		</div>
+
+		<h3 class="ds-subsection__title">Artists</h3>
+		<div class="ds-badge-wrap">
+			<?php foreach ( $ds_artist_badges as $badge ) : ?>
+				<span class="taxonomy-badge <?php echo esc_attr( $badge[0] ); ?>"><?php echo esc_html( $badge[1] ); ?></span>
+			<?php endforeach; ?>
+		</div>
+
+		<h3 class="ds-subsection__title">Categories</h3>
+		<div class="ds-badge-wrap">
+			<?php foreach ( $ds_category_badges as $badge ) : ?>
+				<span class="taxonomy-badge <?php echo esc_attr( $badge[0] ); ?>"><?php echo esc_html( $badge[1] ); ?></span>
+			<?php endforeach; ?>
+		</div>
+	</section>
+
+</article>
+
+<!-- ===================== TWEAK PANEL ===================== -->
+<aside id="ds-tweak-panel" class="ds-tweak" aria-label="Design token tweak panel" hidden>
+	<div class="ds-tweak__header">
+		<h2 class="ds-tweak__title">Tweak Tokens</h2>
+		<button type="button" class="ds-tweak__close button-3 button-small" data-ds-action="toggle" aria-expanded="true">Hide</button>
+	</div>
+
+	<p class="ds-tweak__hint">Local-only proposals. Copy or share the link to send them back.</p>
+
+	<div class="ds-tweak__actions">
+		<button type="button" class="button-2 button-small" data-ds-action="copy">Copy values</button>
+		<button type="button" class="button-1 button-small" data-ds-action="share">Copy share link</button>
+		<button type="button" class="button-danger button-small" data-ds-action="reset">Reset</button>
+	</div>
+	<p class="ds-tweak__feedback" data-ds-feedback aria-live="polite"></p>
+
+	<div class="ds-tweak__group">
+		<h3 class="ds-tweak__group-title">Core Palette</h3>
+		<?php foreach ( $ds_palette_colors as $token => $label ) : ?>
+			<label class="ds-tweak__control">
+				<span class="ds-tweak__control-label"><?php echo esc_html( $label ); ?></span>
+				<input type="color" data-ds-control="color" data-ds-token="<?php echo esc_attr( $token ); ?>" />
+				<code class="ds-tweak__control-token"><?php echo esc_html( $token ); ?></code>
+			</label>
+		<?php endforeach; ?>
+	</div>
+
+	<div class="ds-tweak__group">
+		<h3 class="ds-tweak__group-title">Type Scale</h3>
+		<?php foreach ( $ds_font_sizes as $token => $label ) : ?>
+			<label class="ds-tweak__control">
+				<span class="ds-tweak__control-label"><?php echo esc_html( $label ); ?></span>
+				<input type="text" inputmode="decimal" class="ds-tweak__text" data-ds-control="length" data-ds-token="<?php echo esc_attr( $token ); ?>" placeholder="e.g. 1.25rem" />
+				<code class="ds-tweak__control-token"><?php echo esc_html( $token ); ?></code>
+			</label>
+		<?php endforeach; ?>
+	</div>
+
+	<div class="ds-tweak__group">
+		<h3 class="ds-tweak__group-title">Border Radius</h3>
+		<?php foreach ( $ds_radii as $token => $label ) : ?>
+			<label class="ds-tweak__control">
+				<span class="ds-tweak__control-label"><?php echo esc_html( $label ); ?></span>
+				<input type="text" inputmode="decimal" class="ds-tweak__text" data-ds-control="length" data-ds-token="<?php echo esc_attr( $token ); ?>" placeholder="e.g. 8px" />
+				<code class="ds-tweak__control-token"><?php echo esc_html( $token ); ?></code>
+			</label>
+		<?php endforeach; ?>
+	</div>
+</aside>
+
+<button type="button" id="ds-tweak-toggle" class="button-2 button-medium" data-ds-action="toggle" aria-controls="ds-tweak-panel" aria-expanded="false" hidden>Tweak Tokens</button>
+
+<?php do_action( 'extrachill_after_body_content' ); ?>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## What this is

A **living design system** page for the Extra Chill theme, served at **`/design-system/`**. It's a dynamically-generated, public but **unlisted** style guide (`<meta name="robots" content="noindex, nofollow">`, no login gate). Every specimen on the page **consumes live CSS custom properties** from `assets/css/root.css` — so the page always reflects whatever the shipped `@extrachill/tokens` currently are, including the `@media (prefers-color-scheme: dark)` overrides. No swatch hardcodes a hex or a px.

## URL

`https://extrachill.com/design-system/` — a rewrite flush runs automatically on first load post-deploy via a one-time option flag (`extrachill_design_system_rewrite_flushed`), so the route resolves without a manual permalink resave.

## Sections (v1: tokens + components)

- **Colors** — core palette swatches + identity badge colors (`--artist/team/professional-badge-color`); each shows the token name and its live computed value (filled by JS).
- **Typography** — the `--font-size-xs … 3xl` + `--font-size-brand` scale rendered at size, the three font families (Loft Sans / body / Lobster / mono), and font weights.
- **Spacing** — `--spacing-xs … xl` as bars (display only, not editable).
- **Radius** — `--border-radius-sm/md/lg/xl/pill/circle` as boxes.
- **Components** — real theme classes: `.button-1/2/3/.button-danger` × `.button-small/medium/large`; the three-tier `.notice notice-success/info/error`; a card specimen using `--card-background/--card-shadow/--border-radius-lg`; and **real taxonomy badges** (`.taxonomy-badge.festival-*`, `.location-*`, `.venue-*`, `.artist-susto`, and the `category-*-badge` classes) colored by the live `--badge-*` tokens.

## Live-tweak / export / share (the key feature)

A client-side tweak panel lets a visitor **edit tokens and watch every specimen shift instantly** (`document.documentElement.style.setProperty(--token, value)`):

- Editable in v1: **core palette** (color inputs), **type scale** (`--font-size-*`), **radii** (`--border-radius-*`). Spacing is shown but not editable.
- Controls **initialise from the real shipped values** via `getComputedStyle(document.documentElement).getPropertyValue('--token')` on load — so they reflect `root.css` including dark mode, not hardcoded defaults.
- **Copy values** copies the current overrides as a `:root{}` block to the clipboard.
- **Copy share link** encodes overrides in the **URL hash** so a tweaked link is shareable as-is; on load the hash is read and applied.
- **Reset** clears overrides back to the shipped tokens.

## Persistence

**Client-side only.** Nothing is ever written to the server. The source of truth for tokens stays the `@extrachill/tokens` package — tweaks are local-only proposals (an intro line on the page says so).

## Implementation

- `inc/core/design-system.php` — rewrite rule `^design-system/?$` → query var, query-var whitelist, template swap via `template_include` at **priority 5** (ahead of the main router at 10), `status_header(200)` + `is_404 = false`, `noindex` meta, conditional asset enqueue (root.css + taxonomy-badges.css eagerly under `extrachill-design-system-badges` so badges paint correctly, plus `design-system.css`/`design-system.js`) with `filemtime()` versioning, and a one-time rewrite flush. Helper `extrachill_is_design_system()`, constant `EXTRACHILL_DESIGN_SYSTEM_QUERY_VAR`.
- `inc/core/templates/design-system.php` — `get_header()`/`get_footer()` template; specimens are data-driven from token-name arrays.
- `assets/css/design-system.css` — guide chrome; its own colors/spacing/radii come from tokens, **no `!important`**.
- `assets/js/design-system.js` — tweak-panel logic (init-from-computed, setProperty, hash encode/decode, copy, reset; works without JS — panel is revealed only when JS boots).
- `functions.php` — wires the `require_once` alongside the other `inc/core/` includes.

## Fork decisions

- **Controller was not present in the worktree** despite the brief saying it was already written — the branch was clean at `origin/main`. Built the controller from scratch following the brief's exact spec (rewrite/query-var/template-swap/200/noindex/eager-badge-enqueue/one-time-flush) plus the theme's existing `assets.php` enqueue and `template-router.php` patterns.
- **Panel default state:** open on viewports ≥1024px (with the page given right margin so it isn't occluded), collapsed behind a floating toggle on narrow screens.
- **Color normalisation:** `<input type="color">` needs `#rrggbb`; computed token values may be 3-digit hex / `rgb()` / named, so the JS normalises via a canvas paint before seeding the picker.
- **`calc()` in guide CSS:** a few specimen sizes use `calc(var(--spacing-xl) * N)` — still token-derived, no raw px for theme concerns.

## How I verified

- `php -l inc/core/design-system.php` and `php -l inc/core/templates/design-system.php` — no syntax errors.
- `node --check assets/js/design-system.js` — OK.
- Grep audits: **zero** hardcoded hex in the template or `design-system.css`; **zero** `!important` (only a comment naming the rule); every inline specimen `style=` uses `var(--token)`; no raw `px` in specimen style attrs.
- Confirmed the `require_once` is wired in `functions.php`.
- Confirmed every badge specimen class exists in `taxonomy-badges.css` (no blank badges).
- No host-smoke targets in `homeboy.json`; verification is static (this is a worktree, not a live render).

Did not edit `root.css`/`taxonomy-badges.css` (build artifacts), did not touch `CHANGELOG.md` or version strings.