### PR TITLE
fix: satisfy lint on design-system page assets

### DIFF
--- a/assets/js/design-system.js
+++ b/assets/js/design-system.js
@@ -15,13 +15,16 @@
  * getComputedStyle(document.documentElement) on load, so they reflect root.css
  * (including dark mode) rather than hardcoded defaults.
  *
- * @package ExtraChill
+ * @package
  */
+
+/* global getComputedStyle, history */
+
 ( function () {
 	'use strict';
 
-	var HASH_PREFIX = 'ds=';
-	var root = document.documentElement;
+	const HASH_PREFIX = 'ds=';
+	const root = document.documentElement;
 
 	/**
 	 * Read the live computed value of a token from :root.
@@ -45,7 +48,7 @@
 			return '#000000';
 		}
 
-		var v = value.trim();
+		const v = value.trim();
 		// Already a 6-digit hex.
 		if ( /^#[0-9a-fA-F]{6}$/.test( v ) ) {
 			return v.toLowerCase();
@@ -57,27 +60,27 @@
 
 		// Resolve any other color (rgb(), named, etc.) by painting to a canvas.
 		try {
-			var ctx = document.createElement( 'canvas' ).getContext( '2d' );
+			const ctx = document.createElement( 'canvas' ).getContext( '2d' );
 			ctx.fillStyle = '#000000';
 			ctx.fillStyle = v;
-			var resolved = ctx.fillStyle;
+			const resolved = ctx.fillStyle;
 			if ( /^#[0-9a-fA-F]{6}$/.test( resolved ) ) {
 				return resolved.toLowerCase();
 			}
 			// ctx may return rgb(...) — convert.
-			var m = resolved.match( /rgba?\((\d+),\s*(\d+),\s*(\d+)/ );
+			const m = resolved.match( /rgba?\((\d+),\s*(\d+),\s*(\d+)/ );
 			if ( m ) {
 				return (
 					'#' +
 					[ m[ 1 ], m[ 2 ], m[ 3 ] ]
 						.map( function ( n ) {
-							var h = parseInt( n, 10 ).toString( 16 );
+							const h = parseInt( n, 10 ).toString( 16 );
 							return h.length === 1 ? '0' + h : h;
 						} )
 						.join( '' )
 				);
 			}
-		} catch ( e ) {
+		} catch {
 			// Ignore — fall through to default.
 		}
 
@@ -101,11 +104,11 @@
 	 * @return {Object} token -> value map.
 	 */
 	function collectOverrides() {
-		var overrides = {};
-		var controls = document.querySelectorAll( '[data-ds-token]' );
+		const overrides = {};
+		const controls = document.querySelectorAll( '[data-ds-token]' );
 		controls.forEach( function ( el ) {
-			var token = el.getAttribute( 'data-ds-token' );
-			var inline = root.style.getPropertyValue( token ).trim();
+			const token = el.getAttribute( 'data-ds-token' );
+			const inline = root.style.getPropertyValue( token ).trim();
 			if ( inline ) {
 				overrides[ token ] = inline;
 			}
@@ -120,9 +123,9 @@
 	 * @param {string} [onlyToken] Limit refresh to a single token.
 	 */
 	function refreshComputedLabels( onlyToken ) {
-		var labels = document.querySelectorAll( '[data-ds-computed]' );
+		const labels = document.querySelectorAll( '[data-ds-computed]' );
 		labels.forEach( function ( el ) {
-			var token = el.getAttribute( 'data-ds-computed' );
+			const token = el.getAttribute( 'data-ds-computed' );
 			if ( onlyToken && token !== onlyToken ) {
 				return;
 			}
@@ -135,9 +138,9 @@
 	 */
 	function initControls() {
 		document.querySelectorAll( '[data-ds-control]' ).forEach( function ( input ) {
-			var token = input.getAttribute( 'data-ds-token' );
-			var type = input.getAttribute( 'data-ds-control' );
-			var current = readToken( token );
+			const token = input.getAttribute( 'data-ds-token' );
+			const type = input.getAttribute( 'data-ds-control' );
+			const current = readToken( token );
 
 			if ( type === 'color' ) {
 				input.value = toHex( current );
@@ -156,14 +159,14 @@
 	 * Serialize overrides into the URL hash (shareable as-is).
 	 */
 	function writeHash() {
-		var overrides = collectOverrides();
-		var keys = Object.keys( overrides );
+		const overrides = collectOverrides();
+		const keys = Object.keys( overrides );
 		if ( ! keys.length ) {
 			// Clear hash without adding a history entry.
 			history.replaceState( null, '', window.location.pathname + window.location.search );
 			return;
 		}
-		var encoded = encodeURIComponent( JSON.stringify( overrides ) );
+		const encoded = encodeURIComponent( JSON.stringify( overrides ) );
 		history.replaceState( null, '', '#' + HASH_PREFIX + encoded );
 	}
 
@@ -171,15 +174,15 @@
 	 * Read overrides from the URL hash and apply them on load.
 	 */
 	function applyHash() {
-		var hash = window.location.hash.replace( /^#/, '' );
+		const hash = window.location.hash.replace( /^#/, '' );
 		if ( hash.indexOf( HASH_PREFIX ) !== 0 ) {
 			return;
 		}
-		var raw = hash.slice( HASH_PREFIX.length );
-		var overrides;
+		const raw = hash.slice( HASH_PREFIX.length );
+		let overrides;
 		try {
 			overrides = JSON.parse( decodeURIComponent( raw ) );
-		} catch ( e ) {
+		} catch {
 			return;
 		}
 		if ( ! overrides || typeof overrides !== 'object' ) {
@@ -192,7 +195,7 @@
 
 		// Sync the controls to the applied overrides.
 		document.querySelectorAll( '[data-ds-control]' ).forEach( function ( input ) {
-			var token = input.getAttribute( 'data-ds-token' );
+			const token = input.getAttribute( 'data-ds-token' );
 			if ( ! ( token in overrides ) ) {
 				return;
 			}
@@ -210,12 +213,12 @@
 	 * @return {string} CSS text, or a comment when there are no overrides.
 	 */
 	function buildCssBlock() {
-		var overrides = collectOverrides();
-		var keys = Object.keys( overrides );
+		const overrides = collectOverrides();
+		const keys = Object.keys( overrides );
 		if ( ! keys.length ) {
 			return '/* No token overrides — page reflects shipped @extrachill/tokens. */';
 		}
-		var lines = keys.map( function ( token ) {
+		const lines = keys.map( function ( token ) {
 			return '  ' + token + ': ' + overrides[ token ] + ';';
 		} );
 		return ':root {\n' + lines.join( '\n' ) + '\n}';
@@ -225,7 +228,7 @@
 	 * Copy text to the clipboard with a graceful fallback.
 	 *
 	 * @param {string} text Text to copy.
-	 * @return {Promise}
+	 * @return {Promise} Resolves when the copy succeeds, rejects on failure.
 	 */
 	function copyText( text ) {
 		if ( navigator.clipboard && navigator.clipboard.writeText ) {
@@ -233,7 +236,7 @@
 		}
 		return new Promise( function ( resolve, reject ) {
 			try {
-				var ta = document.createElement( 'textarea' );
+				const ta = document.createElement( 'textarea' );
 				ta.value = text;
 				ta.setAttribute( 'readonly', '' );
 				ta.style.position = 'absolute';
@@ -255,7 +258,7 @@
 	 * @param {string} message Text to display.
 	 */
 	function feedback( message ) {
-		var el = document.querySelector( '[data-ds-feedback]' );
+		const el = document.querySelector( '[data-ds-feedback]' );
 		if ( ! el ) {
 			return;
 		}
@@ -271,7 +274,7 @@
 	 */
 	function resetOverrides() {
 		document.querySelectorAll( '[data-ds-token]' ).forEach( function ( el ) {
-			var token = el.getAttribute( 'data-ds-token' );
+			const token = el.getAttribute( 'data-ds-token' );
 			root.style.removeProperty( token );
 		} );
 		initControls(); // Re-read shipped computed values into the controls.
@@ -284,12 +287,12 @@
 	 * Toggle the tweak panel open/closed.
 	 */
 	function togglePanel() {
-		var panel = document.getElementById( 'ds-tweak-panel' );
-		var toggle = document.getElementById( 'ds-tweak-toggle' );
+		const panel = document.getElementById( 'ds-tweak-panel' );
 		if ( ! panel ) {
 			return;
 		}
-		var willShow = panel.hasAttribute( 'hidden' );
+		const toggle = document.getElementById( 'ds-tweak-toggle' );
+		const willShow = panel.hasAttribute( 'hidden' );
 		if ( willShow ) {
 			panel.removeAttribute( 'hidden' );
 			document.body.classList.add( 'ds-tweak-open' );
@@ -310,7 +313,7 @@
 	 */
 	function initActions() {
 		document.querySelectorAll( '[data-ds-action]' ).forEach( function ( btn ) {
-			var action = btn.getAttribute( 'data-ds-action' );
+			const action = btn.getAttribute( 'data-ds-action' );
 			btn.addEventListener( 'click', function () {
 				if ( action === 'copy' ) {
 					copyText( buildCssBlock() ).then(
@@ -345,8 +348,8 @@
 	 * without JS) and boot everything.
 	 */
 	function boot() {
-		var panel = document.getElementById( 'ds-tweak-panel' );
-		var toggle = document.getElementById( 'ds-tweak-toggle' );
+		const panel = document.getElementById( 'ds-tweak-panel' );
+		const toggle = document.getElementById( 'ds-tweak-toggle' );
 
 		refreshComputedLabels();
 		initControls();
@@ -375,13 +378,13 @@
 				.matchMedia( '(prefers-color-scheme: dark)' )
 				.addEventListener( 'change', function () {
 					// Only refresh controls/labels for tokens without overrides.
-					var overrides = collectOverrides();
+					const overrides = collectOverrides();
 					document.querySelectorAll( '[data-ds-control]' ).forEach( function ( input ) {
-						var token = input.getAttribute( 'data-ds-token' );
+						const token = input.getAttribute( 'data-ds-token' );
 						if ( token in overrides ) {
 							return;
 						}
-						var current = readToken( token );
+						const current = readToken( token );
 						input.value =
 							input.getAttribute( 'data-ds-control' ) === 'color'
 								? toHex( current )

--- a/inc/core/design-system.php
+++ b/inc/core/design-system.php
@@ -156,7 +156,7 @@ function extrachill_design_system_assets() {
 			'extrachill-root',
 			get_stylesheet_directory_uri() . '/assets/css/root.css',
 			array(),
-			filemtime( $root_css_path )
+			(string) filemtime( $root_css_path )
 		);
 	}
 
@@ -168,7 +168,7 @@ function extrachill_design_system_assets() {
 			'extrachill-design-system-badges',
 			get_stylesheet_directory_uri() . '/assets/css/taxonomy-badges.css',
 			array( 'extrachill-root' ),
-			filemtime( $badges_css_path )
+			(string) filemtime( $badges_css_path )
 		);
 	}
 
@@ -179,7 +179,7 @@ function extrachill_design_system_assets() {
 			'extrachill-design-system',
 			get_stylesheet_directory_uri() . '/assets/css/design-system.css',
 			array( 'extrachill-root', 'extrachill-style' ),
-			filemtime( $guide_css_path )
+			(string) filemtime( $guide_css_path )
 		);
 	}
 
@@ -190,7 +190,7 @@ function extrachill_design_system_assets() {
 			'extrachill-design-system',
 			get_stylesheet_directory_uri() . '/assets/js/design-system.js',
 			array(),
-			filemtime( $guide_js_path ),
+			(string) filemtime( $guide_js_path ),
 			array(
 				'strategy'  => 'defer',
 				'in_footer' => true,


### PR DESCRIPTION
## Why

Follow-up to #49 (merged, squash `ecd7678`). `homeboy release extrachill` is blocked by lint findings on the design-system files that merged. This PR makes **our** files lint-clean so the release can proceed. **Style/lint-only — no behavior change** to the tweak panel (init-from-computed, setProperty, hash encode/decode, copy, reset all unchanged).

## What was failing (via `homeboy lint extrachill`)

**`assets/js/design-system.js` — ESLint:**
- `no-var` — `var` → `const`/`let` throughout.
- `jsdoc/empty-tags` — `@package` tag emptied (homeboy's jsdoc rule requires it bare).
- `no-undef` — added `/* global getComputedStyle, history */`.
- `jsdoc/require-returns-description` — described `copyText()`'s `@return`.
- `@wordpress/no-unused-vars-before-return` — moved the `toggle` lookup in `togglePanel()` below the early `return`.
- `no-unused-vars` — the two `catch` blocks that ignore the error now use ES2019 optional catch binding (`catch {}`); the third (which uses `e` via `reject(e)`) is unchanged.

**`inc/core/design-system.php` — PHPStan level 7:**
- `argument.type` (×4) — `filemtime()` returns `int|false` but `wp_enqueue_style`/`wp_enqueue_script`'s `$ver` expects `string|bool|null`. Cast each to `(string) filemtime( … )`. Each call sits inside a `file_exists()` guard and the cast produces an identical cache-busting version string, so behavior is unchanged. (PHPCS passed already; the blocker was PHPStan, not the phpcs nits originally suspected.)

## Verification

- `php -l inc/core/design-system.php` — clean; `node --check assets/js/design-system.js` — clean.
- Per-file homeboy lint — all three design-system files **PASS** (phpcs + eslint + phpstan, zero findings):
  - `assets/js/design-system.js` ✓
  - `inc/core/design-system.php` ✓
  - `inc/core/templates/design-system.php` ✓ (was already clean)
- Whole-tree `homeboy lint extrachill` confirms **none of our files** appear in the findings.

## Scope note

The theme has pre-existing whole-tree lint debt (`header.php`, `footer.php`, `sidebar.php`, `functions.php`, `searchform.php`, `breadcrumbs.php`, `social-links.php`, etc.) that predates this feature and was already failing before #49 merged. That debt is **untouched and out of scope** here — this PR only makes the design-system files clean. If the release gate lints the whole tree rather than changed files, that pre-existing debt is a separate decision (fix-forward or lint baseline), not something this follow-up should expand into.

No `CHANGELOG.md` or version-string edits.