### PR TITLE
fix: render design-system template instead of homepage (#51)

### DIFF
--- a/inc/core/design-system.php
+++ b/inc/core/design-system.php
@@ -101,10 +101,13 @@ function extrachill_design_system_force_200() {
 add_action( 'template_redirect', 'extrachill_design_system_force_200' );
 
 /**
- * Swap in the design-system template ahead of the main template router.
+ * Swap in the design-system template, overriding the main template router.
  *
- * Priority 5 runs before the theme's template-router (priority 10), so the
- * router's is_404() fallback never fires for this route.
+ * `template_include` is a filter, so the LAST callback to run wins. The theme's
+ * main router (inc/core/template-router.php) hooks at priority 10 and — because
+ * the /design-system/ main query has no post/page and is flagged
+ * is_front_page() — would otherwise return front-page.php. Registering at
+ * priority 20 (after the router) lets this filter have the final say.
  *
  * @param string $template Default template path.
  * @return string
@@ -121,7 +124,7 @@ function extrachill_design_system_template( $template ) {
 
 	return $template;
 }
-add_filter( 'template_include', 'extrachill_design_system_template', 5 );
+add_filter( 'template_include', 'extrachill_design_system_template', 20 );
 
 /**
  * Emit a noindex meta tag so the unlisted page stays out of search engines.


### PR DESCRIPTION
## Summary

Fixes #51 — `/design-system/` (v2.7.0) was rendering the homepage instead of the design-system template.

`template_include` is a filter, so the **last** callback wins. The design-system template filter was registered at **priority 5**, but the theme's main router (`template-router.php`) hooks at **priority 10** and runs *after* it — overwriting the return with `front-page.php`, because the `/design-system/` main query has no post and resolves as `is_front_page()`. The route still worked enough to enqueue its assets (`extrachill_is_design_system()` is true), which masked the bug.

Move the filter to **priority 20** so it runs after the router and has the final say. Docblock corrected to explain the filter-ordering semantics.

## Verification

- `php -l` clean; `homeboy lint extrachill --file inc/core/design-system.php` passes.
- Will confirm live render after deploy.