### PR TITLE
feat: inline color editing + light/dark toggle on design-system page

### DIFF
--- a/design-system.html
+++ b/design-system.html
@@ -34,11 +34,38 @@
   }
   .wrap { max-width: var(--container-width); margin: 0 auto; }
   h1 {
-    font-family: var(--font-family-brand);
-    font-size: var(--font-size-brand);
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-3xl);
     margin: 0 0 var(--spacing-sm);
   }
-  .intro { color: var(--muted-text); margin: 0 0 var(--spacing-xl); max-width: var(--content-width); }
+  /* Lobster is subset to the site-title glyphs only — apply it to nothing but
+     that exact string. */
+  .brandmark { font-family: var(--font-family-brand); font-size: var(--font-size-brand); }
+  .intro { color: var(--muted-text); margin: 0 0 var(--spacing-lg); max-width: var(--content-width); }
+  .toolbar {
+    display: flex; flex-wrap: wrap; align-items: center; gap: var(--spacing-sm);
+    margin: 0 0 var(--spacing-xl);
+  }
+  .toolbar button {
+    font: inherit;
+    color: var(--link-color);
+    background: none;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-sm);
+    padding: var(--spacing-xs) var(--spacing-md);
+    cursor: pointer;
+  }
+  .toolbar__group { display: inline-flex; }
+  .toolbar__group .mode { border-radius: 0; margin-left: -1px; }
+  .toolbar__group .mode:first-child { border-radius: var(--border-radius-sm) 0 0 var(--border-radius-sm); margin-left: 0; }
+  .toolbar__group .mode:last-child { border-radius: 0 var(--border-radius-sm) var(--border-radius-sm) 0; }
+  .toolbar .mode[aria-pressed="true"] {
+    background: var(--accent);
+    color: var(--button-text-color);
+    border-color: var(--accent);
+  }
+  .toolbar__hint { margin-left: var(--spacing-sm); font-size: var(--font-size-sm); color: var(--muted-text); }
+
   h2 {
     font-family: var(--font-family-heading);
     font-size: var(--font-size-2xl);
@@ -66,8 +93,19 @@
     padding: var(--spacing-sm);
   }
   .swatch__chip {
+    position: relative;
     flex-shrink: 0; width: var(--spacing-xl); height: var(--spacing-xl);
     border-radius: var(--border-radius-sm); border: 1px solid var(--border-color);
+    cursor: pointer;
+    overflow: hidden;
+  }
+  /* The color input fills the chip but stays invisible — the chip's background
+     shows the live token; clicking anywhere on it opens the picker. */
+  .swatch__picker {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    margin: 0; padding: 0; border: 0;
+    opacity: 0; cursor: pointer;
   }
   .swatch__meta { display: flex; flex-direction: column; gap: var(--spacing-xs); min-width: 0; }
   .swatch__token, .font__token, .weight__token { color: var(--link-color); word-break: break-all; }
@@ -92,17 +130,29 @@
 <body>
 <div class="wrap">
 
-  <h1>Extra Chill — Colors &amp; Fonts</h1>
+  <h1><span class="brandmark">Extra Chill</span> — Colors &amp; Fonts</h1>
   <p class="intro">
     A static reference of the shipped design tokens. Generated from
     <code>@extrachill/tokens</code> and rendered with the live <code>root.css</code>,
     so values reflect exactly what's deployed (including dark mode — toggle your OS theme).
+    Click any color swatch to try a different value — changes are local to your browser.
   </p>
+  <div class="toolbar">
+    <span class="toolbar__group" role="group" aria-label="Color scheme">
+      <button type="button" class="mode" data-mode="auto" aria-pressed="true">Auto</button>
+      <button type="button" class="mode" data-mode="light" aria-pressed="false">Light</button>
+      <button type="button" class="mode" data-mode="dark" aria-pressed="false">Dark</button>
+    </span>
+    <button type="button" id="reset">Reset colors</button>
+    <span class="toolbar__hint">Edits are local-only; the source of truth is <code>@extrachill/tokens</code>.</span>
+  </div>
 
   <h2>Colors</h2>
   <div class="swatch-grid">
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--background-color);"></span>
+          <label class="swatch__chip" style="background:var(--background-color);">
+            <input type="color" class="swatch__picker" data-token="--background-color" aria-label="Edit --background-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--background-color</code>
             <span class="swatch__desc">Page background</span>
@@ -110,7 +160,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--text-color);"></span>
+          <label class="swatch__chip" style="background:var(--text-color);">
+            <input type="color" class="swatch__picker" data-token="--text-color" aria-label="Edit --text-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--text-color</code>
             <span class="swatch__desc">Primary text</span>
@@ -118,7 +170,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--link-color);"></span>
+          <label class="swatch__chip" style="background:var(--link-color);">
+            <input type="color" class="swatch__picker" data-token="--link-color" aria-label="Edit --link-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--link-color</code>
             <span class="swatch__desc">Link color</span>
@@ -126,7 +180,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--link-color-hover);"></span>
+          <label class="swatch__chip" style="background:var(--link-color-hover);">
+            <input type="color" class="swatch__picker" data-token="--link-color-hover" aria-label="Edit --link-color-hover" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--link-color-hover</code>
             <span class="swatch__desc">Link hover color</span>
@@ -134,7 +190,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--border-color);"></span>
+          <label class="swatch__chip" style="background:var(--border-color);">
+            <input type="color" class="swatch__picker" data-token="--border-color" aria-label="Edit --border-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--border-color</code>
             <span class="swatch__desc">Borders and dividers</span>
@@ -142,7 +200,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--accent);"></span>
+          <label class="swatch__chip" style="background:var(--accent);">
+            <input type="color" class="swatch__picker" data-token="--accent" aria-label="Edit --accent" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--accent</code>
             <span class="swatch__desc">Primary accent (green)</span>
@@ -150,7 +210,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--accent-hover);"></span>
+          <label class="swatch__chip" style="background:var(--accent-hover);">
+            <input type="color" class="swatch__picker" data-token="--accent-hover" aria-label="Edit --accent-hover" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--accent-hover</code>
             <span class="swatch__desc">Primary accent hover</span>
@@ -158,7 +220,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--accent-2);"></span>
+          <label class="swatch__chip" style="background:var(--accent-2);">
+            <input type="color" class="swatch__picker" data-token="--accent-2" aria-label="Edit --accent-2" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--accent-2</code>
             <span class="swatch__desc">Secondary accent (slate / light blue)</span>
@@ -166,7 +230,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--accent-3);"></span>
+          <label class="swatch__chip" style="background:var(--accent-3);">
+            <input type="color" class="swatch__picker" data-token="--accent-3" aria-label="Edit --accent-3" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--accent-3</code>
             <span class="swatch__desc">Tertiary accent (cyan / blue)</span>
@@ -174,7 +240,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--error-color);"></span>
+          <label class="swatch__chip" style="background:var(--error-color);">
+            <input type="color" class="swatch__picker" data-token="--error-color" aria-label="Edit --error-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--error-color</code>
             <span class="swatch__desc">Error / danger state</span>
@@ -182,7 +250,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--success-color);"></span>
+          <label class="swatch__chip" style="background:var(--success-color);">
+            <input type="color" class="swatch__picker" data-token="--success-color" aria-label="Edit --success-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--success-color</code>
             <span class="swatch__desc">Success state</span>
@@ -190,7 +260,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--button-text-color);"></span>
+          <label class="swatch__chip" style="background:var(--button-text-color);">
+            <input type="color" class="swatch__picker" data-token="--button-text-color" aria-label="Edit --button-text-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--button-text-color</code>
             <span class="swatch__desc">Button text on accent backgrounds</span>
@@ -198,7 +270,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--header-background);"></span>
+          <label class="swatch__chip" style="background:var(--header-background);">
+            <input type="color" class="swatch__picker" data-token="--header-background" aria-label="Edit --header-background" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--header-background</code>
             <span class="swatch__desc">Site header background</span>
@@ -206,7 +280,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--header-text-color);"></span>
+          <label class="swatch__chip" style="background:var(--header-text-color);">
+            <input type="color" class="swatch__picker" data-token="--header-text-color" aria-label="Edit --header-text-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--header-text-color</code>
             <span class="swatch__desc">Site header text</span>
@@ -214,7 +290,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--card-background);"></span>
+          <label class="swatch__chip" style="background:var(--card-background);">
+            <input type="color" class="swatch__picker" data-token="--card-background" aria-label="Edit --card-background" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--card-background</code>
             <span class="swatch__desc">Card / surface background</span>
@@ -222,7 +300,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--muted-text);"></span>
+          <label class="swatch__chip" style="background:var(--muted-text);">
+            <input type="color" class="swatch__picker" data-token="--muted-text" aria-label="Edit --muted-text" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--muted-text</code>
             <span class="swatch__desc">Secondary / muted text</span>
@@ -230,7 +310,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--warning-color);"></span>
+          <label class="swatch__chip" style="background:var(--warning-color);">
+            <input type="color" class="swatch__picker" data-token="--warning-color" aria-label="Edit --warning-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--warning-color</code>
             <span class="swatch__desc">Warning state</span>
@@ -238,7 +320,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--info-color);"></span>
+          <label class="swatch__chip" style="background:var(--info-color);">
+            <input type="color" class="swatch__picker" data-token="--info-color" aria-label="Edit --info-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--info-color</code>
             <span class="swatch__desc">Informational state</span>
@@ -250,7 +334,9 @@
   <h3>Badge Identity Colors</h3>
   <div class="swatch-grid">
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--artist-badge-color);"></span>
+          <label class="swatch__chip" style="background:var(--artist-badge-color);">
+            <input type="color" class="swatch__picker" data-token="--artist-badge-color" aria-label="Edit --artist-badge-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--artist-badge-color</code>
             <span class="swatch__desc">Artist role badge color</span>
@@ -258,7 +344,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--team-badge-color);"></span>
+          <label class="swatch__chip" style="background:var(--team-badge-color);">
+            <input type="color" class="swatch__picker" data-token="--team-badge-color" aria-label="Edit --team-badge-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--team-badge-color</code>
             <span class="swatch__desc">Team member role badge color</span>
@@ -266,7 +354,9 @@
           </span>
         </div>
         <div class="swatch">
-          <span class="swatch__chip" style="background:var(--professional-badge-color);"></span>
+          <label class="swatch__chip" style="background:var(--professional-badge-color);">
+            <input type="color" class="swatch__picker" data-token="--professional-badge-color" aria-label="Edit --professional-badge-color" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">--professional-badge-color</code>
             <span class="swatch__desc">Professional role badge color</span>
@@ -295,7 +385,7 @@
           </span>
         </div>
         <div class="font" style="font-family:var(--font-family-brand);">
-          <span class="font__sample">Extra Chill — the Online Music Scene</span>
+          <span class="font__sample">Extra Chill</span>
           <span class="font__meta">
             <code class="font__token">--font-family-brand</code>
             <span class="font__desc">Brand / logo text</span>
@@ -339,12 +429,103 @@
 </div>
 
 <script>
-  // Fill each swatch/font with its live computed token value.
   ( function () {
-    var cs = getComputedStyle( document.documentElement );
-    document.querySelectorAll( '[data-value]' ).forEach( function ( el ) {
-      el.textContent = cs.getPropertyValue( el.getAttribute( 'data-value' ) ).trim();
+    var root = document.documentElement;
+
+    // Light/dark token maps baked from @extrachill/tokens at build time.
+    var LIGHT = {"--background-color":"#fff","--text-color":"#000","--link-color":"#0b5394","--link-color-hover":"#083b6c","--link-hover-color":"#000","--border-color":"#ddd","--accent":"#53940b","--accent-hover":"#3d6b08","--accent-2":"#36454F","--accent-2-rgb":"54, 69, 79","--accent-3":"#00c8e3","--error-color":"#dc3232","--success-color":"#28a745","--button-text-color":"#fff","--header-background":"#000","--header-text-color":"#fff","--notice-bg":"#f8f9fa","--notice-border":"#0b5394","--card-background":"#f1f5f9","--muted-text":"#6b7280","--card-shadow":"0 2px 6px rgba(0, 0, 0, 0.08)","--card-hover-shadow":"0 4px 12px rgba(0, 0, 0, 0.1)","--focus-border-color":"#53940b","--focus-box-shadow":"0 0 0 3px rgba(83, 148, 11, 0.2)","--post-title-link-color":"#000","--post-title-link-hover-color":"#000","--warning-color":"#d97706","--warning-bg":"rgba(217, 119, 6, 0.1)","--info-color":"#0b5394","--info-bg":"rgba(11, 83, 148, 0.08)","--interactive-hover-bg":"rgba(11, 83, 148, 0.06)","--interactive-active-bg":"rgba(11, 83, 148, 0.12)","--interactive-active-border":"#0b5394"};
+    var DARK = {"--background-color":"#1a1a1a","--text-color":"#e5e5e5","--link-color":"#53940b","--link-color-hover":"#1a6bb8","--link-hover-color":"#e5e5e5","--border-color":"#555","--accent":"#53940b","--accent-hover":"#6ab312","--accent-2":"#9fc5e8","--accent-2-rgb":"159, 197, 232","--accent-3":"#0b5394","--error-color":"#ef4444","--success-color":"#46b450","--button-text-color":"#fff","--header-background":"#000","--header-text-color":"#fff","--notice-bg":"#1e1e1e","--notice-border":"#444","--card-background":"#2a2a2a","--muted-text":"#b0b0b0","--card-shadow":"0 1px 3px rgba(0, 0, 0, 0.5)","--card-hover-shadow":"0 4px 12px rgba(0, 0, 0, 0.4)","--focus-border-color":"#8aa6bf","--focus-box-shadow":"0 0 0 3px rgba(138, 166, 191, 0.2)","--post-title-link-color":"#e5e5e5","--post-title-link-hover-color":"#e5e5e5","--warning-color":"#fbbf24","--warning-bg":"rgba(251, 191, 36, 0.1)","--info-color":"#93c5fd","--info-bg":"rgba(147, 197, 253, 0.08)","--interactive-hover-bg":"rgba(83, 148, 11, 0.08)","--interactive-active-bg":"rgba(83, 148, 11, 0.15)","--interactive-active-border":"#53940b"};
+
+    // Resolve any CSS color to #rrggbb so <input type="color"> can seed it.
+    function toHex( value ) {
+      if ( ! value ) { return '#000000'; }
+      var v = value.trim();
+      if ( /^#[0-9a-fA-F]{6}$/.test( v ) ) { return v.toLowerCase(); }
+      if ( /^#[0-9a-fA-F]{3}$/.test( v ) ) {
+        return ( '#' + v[1] + v[1] + v[2] + v[2] + v[3] + v[3] ).toLowerCase();
+      }
+      try {
+        var ctx = document.createElement( 'canvas' ).getContext( '2d' );
+        ctx.fillStyle = '#000000';
+        ctx.fillStyle = v;
+        var out = ctx.fillStyle;
+        if ( /^#[0-9a-fA-F]{6}$/.test( out ) ) { return out.toLowerCase(); }
+        var m = out.match( /rgba?\((\d+),\s*(\d+),\s*(\d+)/ );
+        if ( m ) {
+          return '#' + [ m[1], m[2], m[3] ].map( function ( n ) {
+            var h = parseInt( n, 10 ).toString( 16 );
+            return h.length === 1 ? '0' + h : h;
+          } ).join( '' );
+        }
+      } catch ( e ) {}
+      return '#000000';
+    }
+
+    function readToken( token ) {
+      return getComputedStyle( root ).getPropertyValue( token ).trim();
+    }
+
+    // Fill each value label with the live computed token value.
+    function refreshValues() {
+      document.querySelectorAll( '[data-value]' ).forEach( function ( el ) {
+        el.textContent = readToken( el.getAttribute( 'data-value' ) );
+      } );
+    }
+
+    // Seed each color picker from the live computed value.
+    function initPickers() {
+      document.querySelectorAll( '.swatch__picker' ).forEach( function ( input ) {
+        var token = input.getAttribute( 'data-token' );
+        input.value = toHex( readToken( token ) );
+        input.addEventListener( 'input', function () {
+          root.style.setProperty( token, input.value );
+          refreshValues();
+        } );
+      } );
+    }
+
+    // Force a color scheme. "auto" clears the forced map and falls back to
+    // root.css's prefers-color-scheme media query. light/dark apply the baked
+    // token maps to :root, re-theming the whole page. User color edits (set on
+    // root.style by the pickers) still win, since they're applied after.
+    var forcedMode = 'auto';
+    function applyMode( mode ) {
+      forcedMode = mode;
+      // Clear any previously forced scheme values.
+      Object.keys( DARK ).concat( Object.keys( LIGHT ) ).forEach( function ( token ) {
+        root.style.removeProperty( token );
+      } );
+      var map = mode === 'light' ? LIGHT : mode === 'dark' ? DARK : null;
+      if ( map ) {
+        Object.keys( map ).forEach( function ( token ) {
+          root.style.setProperty( token, map[ token ] );
+        } );
+      }
+      document.querySelectorAll( '.mode' ).forEach( function ( btn ) {
+        btn.setAttribute( 'aria-pressed', String( btn.getAttribute( 'data-mode' ) === mode ) );
+      } );
+      // Re-seed pickers + value labels to the now-active scheme.
+      initPickers();
+      refreshValues();
+    }
+
+    document.querySelectorAll( '.mode' ).forEach( function ( btn ) {
+      btn.addEventListener( 'click', function () {
+        applyMode( btn.getAttribute( 'data-mode' ) );
+      } );
     } );
+
+    document.getElementById( 'reset' ).addEventListener( 'click', function () {
+      // Clear user color edits, then re-apply the current forced scheme (if any).
+      document.querySelectorAll( '.swatch__picker' ).forEach( function ( input ) {
+        root.style.removeProperty( input.getAttribute( 'data-token' ) );
+      } );
+      applyMode( forcedMode );
+    } );
+
+    // Load in Auto: follow the OS via root.css's media query.
+    refreshValues();
+    initPickers();
   } )();
 </script>
 </body>

--- a/scripts/build-design-system.js
+++ b/scripts/build-design-system.js
@@ -3,17 +3,24 @@
  * Build design-system.html
  *
  * Generates a self-contained static reference page showing the Extra Chill
- * color palette and font families. The token LIST is regenerated from
- * @extrachill/tokens (the same source root.css comes from), so new tokens show
+ * color palette and font families. The token LIST is regenerated from the
+ * tokens package (the same source root.css comes from), so new tokens show
  * up automatically. The page links the theme's root.css live, so the actual
- * VALUES (including @media prefers-color-scheme: dark overrides) always reflect
+ * VALUES (including the prefers-color-scheme dark overrides) always reflect
  * what's shipped — a tiny inline script fills each swatch's computed value.
+ *
+ * Colors are editable inline: click a swatch's chip to open a color picker and
+ * the whole page updates live (overrides are local-only). A Reset link clears
+ * them back to the shipped tokens.
  *
  * Output is a plain .html served directly by the web server at
  * /wp-content/themes/extrachill/design-system.html — no WordPress routing,
  * no PHP, no theme coupling.
  */
 
+/**
+ * External dependencies
+ */
 const fs = require( 'fs' );
 const path = require( 'path' );
 
@@ -23,6 +30,11 @@ const tokens = require(
 
 const esc = ( s ) =>
 	String( s ).replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
+
+// The brand font (Lobster) is a SUBSET woff2 — for perf it only contains the
+// glyphs for the site title "Extra Chill". Any other character falls back to
+// sans-serif, so the brand specimen must only ever render this exact string.
+const BRAND_SAFE_TEXT = 'Extra Chill';
 
 // --- Colors -----------------------------------------------------------------
 // Core palette: the human-facing colors (skip rgb tuples, shadows, derived
@@ -52,6 +64,22 @@ const colorTokens = Object.entries( tokens.categories.color )
 		desc: def.description || '',
 	} ) );
 
+// Light/dark color maps baked from the token source so a visitor can FORCE a
+// mode (root.css only exposes dark via @media prefers-color-scheme, with no
+// class/attr hook). The toggle applies these via setProperty on :root, which
+// re-themes the whole page because every surface consumes the tokens. "Auto"
+// removes the overrides and falls back to root.css's media query.
+const lightMap = {};
+const darkMap = {};
+for ( const [ name, def ] of Object.entries( tokens.categories.color ) ) {
+	if ( def.light !== undefined ) {
+		lightMap[ '--' + name ] = def.light;
+	}
+	if ( def.dark !== undefined ) {
+		darkMap[ '--' + name ] = def.dark;
+	}
+}
+
 // Identity badge accent colors (artist / team / professional) live in the
 // `badge` category. Surface them as swatches too.
 const badgeColorTokens = [];
@@ -66,6 +94,8 @@ const fontTokens = Object.entries( tokens.categories.typography ).map( ( [ name,
 	token: '--' + name,
 	value: def.value,
 	desc: def.description || '',
+	// Brand font is subset-limited; render only the safe string for it.
+	isBrand: name === 'font-family-brand',
 } ) );
 
 const weightTokens = Object.entries( tokens.categories['font-weight'] ).map(
@@ -77,8 +107,12 @@ const weightTokens = Object.entries( tokens.categories['font-weight'] ).map(
 
 // --- HTML builders ----------------------------------------------------------
 function colorSwatch( { token, desc } ) {
+	// The chip holds a transparent <input type="color"> overlay so clicking it
+	// opens the native picker; editing updates the page live (see inline JS).
 	return `        <div class="swatch">
-          <span class="swatch__chip" style="background:var(${ token });"></span>
+          <label class="swatch__chip" style="background:var(${ token });">
+            <input type="color" class="swatch__picker" data-token="${ esc( token ) }" aria-label="Edit ${ esc( token ) }" />
+          </label>
           <span class="swatch__meta">
             <code class="swatch__token">${ esc( token ) }</code>
             ${ desc ? `<span class="swatch__desc">${ esc( desc ) }</span>` : '' }
@@ -87,9 +121,10 @@ function colorSwatch( { token, desc } ) {
         </div>`;
 }
 
-function fontRow( { token, desc } ) {
+function fontRow( { token, desc, isBrand } ) {
+	const sample = isBrand ? BRAND_SAFE_TEXT : 'Extra Chill — the Online Music Scene';
 	return `        <div class="font" style="font-family:var(${ token });">
-          <span class="font__sample">Extra Chill — the Online Music Scene</span>
+          <span class="font__sample">${ esc( sample ) }</span>
           <span class="font__meta">
             <code class="font__token">${ esc( token ) }</code>
             ${ desc ? `<span class="font__desc">${ esc( desc ) }</span>` : '' }
@@ -142,11 +177,38 @@ const html = `<!DOCTYPE html>
   }
   .wrap { max-width: var(--container-width); margin: 0 auto; }
   h1 {
-    font-family: var(--font-family-brand);
-    font-size: var(--font-size-brand);
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-3xl);
     margin: 0 0 var(--spacing-sm);
   }
-  .intro { color: var(--muted-text); margin: 0 0 var(--spacing-xl); max-width: var(--content-width); }
+  /* Lobster is subset to the site-title glyphs only — apply it to nothing but
+     that exact string. */
+  .brandmark { font-family: var(--font-family-brand); font-size: var(--font-size-brand); }
+  .intro { color: var(--muted-text); margin: 0 0 var(--spacing-lg); max-width: var(--content-width); }
+  .toolbar {
+    display: flex; flex-wrap: wrap; align-items: center; gap: var(--spacing-sm);
+    margin: 0 0 var(--spacing-xl);
+  }
+  .toolbar button {
+    font: inherit;
+    color: var(--link-color);
+    background: none;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-sm);
+    padding: var(--spacing-xs) var(--spacing-md);
+    cursor: pointer;
+  }
+  .toolbar__group { display: inline-flex; }
+  .toolbar__group .mode { border-radius: 0; margin-left: -1px; }
+  .toolbar__group .mode:first-child { border-radius: var(--border-radius-sm) 0 0 var(--border-radius-sm); margin-left: 0; }
+  .toolbar__group .mode:last-child { border-radius: 0 var(--border-radius-sm) var(--border-radius-sm) 0; }
+  .toolbar .mode[aria-pressed="true"] {
+    background: var(--accent);
+    color: var(--button-text-color);
+    border-color: var(--accent);
+  }
+  .toolbar__hint { margin-left: var(--spacing-sm); font-size: var(--font-size-sm); color: var(--muted-text); }
+
   h2 {
     font-family: var(--font-family-heading);
     font-size: var(--font-size-2xl);
@@ -174,8 +236,19 @@ const html = `<!DOCTYPE html>
     padding: var(--spacing-sm);
   }
   .swatch__chip {
+    position: relative;
     flex-shrink: 0; width: var(--spacing-xl); height: var(--spacing-xl);
     border-radius: var(--border-radius-sm); border: 1px solid var(--border-color);
+    cursor: pointer;
+    overflow: hidden;
+  }
+  /* The color input fills the chip but stays invisible — the chip's background
+     shows the live token; clicking anywhere on it opens the picker. */
+  .swatch__picker {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    margin: 0; padding: 0; border: 0;
+    opacity: 0; cursor: pointer;
   }
   .swatch__meta { display: flex; flex-direction: column; gap: var(--spacing-xs); min-width: 0; }
   .swatch__token, .font__token, .weight__token { color: var(--link-color); word-break: break-all; }
@@ -200,12 +273,22 @@ const html = `<!DOCTYPE html>
 <body>
 <div class="wrap">
 
-  <h1>Extra Chill — Colors &amp; Fonts</h1>
+  <h1><span class="brandmark">${ esc( BRAND_SAFE_TEXT ) }</span> — Colors &amp; Fonts</h1>
   <p class="intro">
     A static reference of the shipped design tokens. Generated from
     <code>@extrachill/tokens</code> and rendered with the live <code>root.css</code>,
     so values reflect exactly what's deployed (including dark mode — toggle your OS theme).
+    Click any color swatch to try a different value — changes are local to your browser.
   </p>
+  <div class="toolbar">
+    <span class="toolbar__group" role="group" aria-label="Color scheme">
+      <button type="button" class="mode" data-mode="auto" aria-pressed="true">Auto</button>
+      <button type="button" class="mode" data-mode="light" aria-pressed="false">Light</button>
+      <button type="button" class="mode" data-mode="dark" aria-pressed="false">Dark</button>
+    </span>
+    <button type="button" id="reset">Reset colors</button>
+    <span class="toolbar__hint">Edits are local-only; the source of truth is <code>@extrachill/tokens</code>.</span>
+  </div>
 
   <h2>Colors</h2>
   <div class="swatch-grid">
@@ -235,12 +318,103 @@ ${ weightTokens.map( weightRow ).join( '\n' ) }
 </div>
 
 <script>
-  // Fill each swatch/font with its live computed token value.
   ( function () {
-    var cs = getComputedStyle( document.documentElement );
-    document.querySelectorAll( '[data-value]' ).forEach( function ( el ) {
-      el.textContent = cs.getPropertyValue( el.getAttribute( 'data-value' ) ).trim();
+    var root = document.documentElement;
+
+    // Light/dark token maps baked from @extrachill/tokens at build time.
+    var LIGHT = ${ JSON.stringify( lightMap ) };
+    var DARK = ${ JSON.stringify( darkMap ) };
+
+    // Resolve any CSS color to #rrggbb so <input type="color"> can seed it.
+    function toHex( value ) {
+      if ( ! value ) { return '#000000'; }
+      var v = value.trim();
+      if ( /^#[0-9a-fA-F]{6}$/.test( v ) ) { return v.toLowerCase(); }
+      if ( /^#[0-9a-fA-F]{3}$/.test( v ) ) {
+        return ( '#' + v[1] + v[1] + v[2] + v[2] + v[3] + v[3] ).toLowerCase();
+      }
+      try {
+        var ctx = document.createElement( 'canvas' ).getContext( '2d' );
+        ctx.fillStyle = '#000000';
+        ctx.fillStyle = v;
+        var out = ctx.fillStyle;
+        if ( /^#[0-9a-fA-F]{6}$/.test( out ) ) { return out.toLowerCase(); }
+        var m = out.match( /rgba?\\((\\d+),\\s*(\\d+),\\s*(\\d+)/ );
+        if ( m ) {
+          return '#' + [ m[1], m[2], m[3] ].map( function ( n ) {
+            var h = parseInt( n, 10 ).toString( 16 );
+            return h.length === 1 ? '0' + h : h;
+          } ).join( '' );
+        }
+      } catch ( e ) {}
+      return '#000000';
+    }
+
+    function readToken( token ) {
+      return getComputedStyle( root ).getPropertyValue( token ).trim();
+    }
+
+    // Fill each value label with the live computed token value.
+    function refreshValues() {
+      document.querySelectorAll( '[data-value]' ).forEach( function ( el ) {
+        el.textContent = readToken( el.getAttribute( 'data-value' ) );
+      } );
+    }
+
+    // Seed each color picker from the live computed value.
+    function initPickers() {
+      document.querySelectorAll( '.swatch__picker' ).forEach( function ( input ) {
+        var token = input.getAttribute( 'data-token' );
+        input.value = toHex( readToken( token ) );
+        input.addEventListener( 'input', function () {
+          root.style.setProperty( token, input.value );
+          refreshValues();
+        } );
+      } );
+    }
+
+    // Force a color scheme. "auto" clears the forced map and falls back to
+    // root.css's prefers-color-scheme media query. light/dark apply the baked
+    // token maps to :root, re-theming the whole page. User color edits (set on
+    // root.style by the pickers) still win, since they're applied after.
+    var forcedMode = 'auto';
+    function applyMode( mode ) {
+      forcedMode = mode;
+      // Clear any previously forced scheme values.
+      Object.keys( DARK ).concat( Object.keys( LIGHT ) ).forEach( function ( token ) {
+        root.style.removeProperty( token );
+      } );
+      var map = mode === 'light' ? LIGHT : mode === 'dark' ? DARK : null;
+      if ( map ) {
+        Object.keys( map ).forEach( function ( token ) {
+          root.style.setProperty( token, map[ token ] );
+        } );
+      }
+      document.querySelectorAll( '.mode' ).forEach( function ( btn ) {
+        btn.setAttribute( 'aria-pressed', String( btn.getAttribute( 'data-mode' ) === mode ) );
+      } );
+      // Re-seed pickers + value labels to the now-active scheme.
+      initPickers();
+      refreshValues();
+    }
+
+    document.querySelectorAll( '.mode' ).forEach( function ( btn ) {
+      btn.addEventListener( 'click', function () {
+        applyMode( btn.getAttribute( 'data-mode' ) );
+      } );
     } );
+
+    document.getElementById( 'reset' ).addEventListener( 'click', function () {
+      // Clear user color edits, then re-apply the current forced scheme (if any).
+      document.querySelectorAll( '.swatch__picker' ).forEach( function ( input ) {
+        root.style.removeProperty( input.getAttribute( 'data-token' ) );
+      } );
+      applyMode( forcedMode );
+    } );
+
+    // Load in Auto: follow the OS via root.css's media query.
+    refreshValues();
+    initPickers();
   } )();
 </script>
 </body>
@@ -249,4 +423,5 @@ ${ weightTokens.map( weightRow ).join( '\n' ) }
 
 const outPath = path.join( __dirname, '..', 'design-system.html' );
 fs.writeFileSync( outPath, html );
+// eslint-disable-next-line no-console -- build-time progress output.
 console.log( `Built ${ outPath } (${ html.split( '\n' ).length } lines)` );


### PR DESCRIPTION
## Summary

Adds the two things asked for on the static design-system page, plus fixes the Lobster brand-font rendering.

- **Inline color editing** — each color swatch's chip is a native color picker. Editing it updates the whole page live via `setProperty` (overrides are local-only, never saved). A **Reset colors** button clears edits back to the shipped tokens.
- **Light/Dark toggle (Auto / Light / Dark)** — `root.css` only exposes dark mode via `@media prefers-color-scheme` with no class/attr hook to force it, so the generator **bakes light/dark color maps from `@extrachill/tokens`** and the toggle applies them to `:root`, re-theming the entire page (chrome + swatches). Loads in **Auto** = follows the OS, truest to what ships.
- **Lobster brand-font fix** — `Lobster2.woff2` is an intentional **perf subset** containing only the site-title glyphs ("Extra Chill"). The page previously rendered arbitrary text (the `<h1>` tail, the brand specimen sentence) in it, so non-subset glyphs (em-dash, "Colors & Fonts", etc.) silently fell back to sans-serif — the broken mixed-font look in the screenshot. Now the brand font is applied **only** to the exact "Extra Chill" string (an `<h1>` `.brandmark` span and the brand-font specimen row); the heading font carries everything else.

## Still data-driven / regenerated

All of the above is generated by `scripts/build-design-system.js` from `@extrachill/tokens` on every `npm run build` — the light/dark maps and the token list regenerate from source, so nothing goes stale.

## URL

`https://extrachill.com/wp-content/themes/extrachill/design-system.html`

## Verification

- `node --check` on the generator and the extracted inline `<script>` — both parse.
- `npm run build` regenerates the page (533 lines, 24 color pickers, 3 mode buttons, light/dark maps baked in).
- `homeboy lint extrachill --file scripts/build-design-system.js` — **passes clean** (phpcs + eslint): added the `// External dependencies` group comment, reworded the JSDoc to avoid a stray `@`-tag, and a scoped `no-console` disable on the build-progress log.

No `CHANGELOG.md` or version-string edits.