### PR TITLE
fix: keep token names + descriptions on design-system swatches

### DIFF
--- a/design-system.html
+++ b/design-system.html
@@ -108,7 +108,8 @@
     opacity: 0; cursor: pointer;
   }
   .swatch__meta { display: flex; flex-direction: column; gap: var(--spacing-xs); min-width: 0; }
-  .swatch__label, .font__label, .weight__label { font-size: var(--font-size-sm); }
+  .swatch__token, .font__token, .weight__token { color: var(--link-color); word-break: break-all; }
+  .swatch__label, .font__label, .weight__label { font-size: var(--font-size-sm); color: var(--muted-text); }
   .swatch__value { font-size: var(--font-size-xs); color: var(--muted-text); }
 
   .fonts { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--spacing-md); }
@@ -119,7 +120,7 @@
     padding: var(--spacing-md);
   }
   .font__sample { display: block; font-size: var(--font-size-xl); margin-bottom: var(--spacing-sm); }
-  .font__label { color: var(--muted-text); }
+  .font__meta { display: flex; flex-direction: column; gap: var(--spacing-xs); }
 
   .weights { display: flex; flex-wrap: wrap; gap: var(--spacing-lg); }
   .weight { display: flex; flex-direction: column; gap: var(--spacing-xs); }
@@ -152,8 +153,9 @@
             <input type="color" class="swatch__picker" data-token="--background-color" aria-label="Edit Page background" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--background-color</code>
             <span class="swatch__label">Page background</span>
-            <span class="swatch__value" data-value="--background-color">…</span>
+            <code class="swatch__value" data-value="--background-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -161,8 +163,9 @@
             <input type="color" class="swatch__picker" data-token="--text-color" aria-label="Edit Primary text" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--text-color</code>
             <span class="swatch__label">Primary text</span>
-            <span class="swatch__value" data-value="--text-color">…</span>
+            <code class="swatch__value" data-value="--text-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -170,8 +173,9 @@
             <input type="color" class="swatch__picker" data-token="--link-color" aria-label="Edit Link color" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--link-color</code>
             <span class="swatch__label">Link color</span>
-            <span class="swatch__value" data-value="--link-color">…</span>
+            <code class="swatch__value" data-value="--link-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -179,8 +183,9 @@
             <input type="color" class="swatch__picker" data-token="--link-color-hover" aria-label="Edit Link hover color" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--link-color-hover</code>
             <span class="swatch__label">Link hover color</span>
-            <span class="swatch__value" data-value="--link-color-hover">…</span>
+            <code class="swatch__value" data-value="--link-color-hover">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -188,8 +193,9 @@
             <input type="color" class="swatch__picker" data-token="--border-color" aria-label="Edit Borders and dividers" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--border-color</code>
             <span class="swatch__label">Borders and dividers</span>
-            <span class="swatch__value" data-value="--border-color">…</span>
+            <code class="swatch__value" data-value="--border-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -197,8 +203,9 @@
             <input type="color" class="swatch__picker" data-token="--accent" aria-label="Edit Primary accent (green)" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--accent</code>
             <span class="swatch__label">Primary accent (green)</span>
-            <span class="swatch__value" data-value="--accent">…</span>
+            <code class="swatch__value" data-value="--accent">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -206,8 +213,9 @@
             <input type="color" class="swatch__picker" data-token="--accent-hover" aria-label="Edit Primary accent hover" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--accent-hover</code>
             <span class="swatch__label">Primary accent hover</span>
-            <span class="swatch__value" data-value="--accent-hover">…</span>
+            <code class="swatch__value" data-value="--accent-hover">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -215,8 +223,9 @@
             <input type="color" class="swatch__picker" data-token="--accent-2" aria-label="Edit Secondary accent (slate / light blue)" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--accent-2</code>
             <span class="swatch__label">Secondary accent (slate / light blue)</span>
-            <span class="swatch__value" data-value="--accent-2">…</span>
+            <code class="swatch__value" data-value="--accent-2">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -224,8 +233,9 @@
             <input type="color" class="swatch__picker" data-token="--accent-3" aria-label="Edit Tertiary accent (cyan / blue)" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--accent-3</code>
             <span class="swatch__label">Tertiary accent (cyan / blue)</span>
-            <span class="swatch__value" data-value="--accent-3">…</span>
+            <code class="swatch__value" data-value="--accent-3">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -233,8 +243,9 @@
             <input type="color" class="swatch__picker" data-token="--error-color" aria-label="Edit Error / danger state" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--error-color</code>
             <span class="swatch__label">Error / danger state</span>
-            <span class="swatch__value" data-value="--error-color">…</span>
+            <code class="swatch__value" data-value="--error-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -242,8 +253,9 @@
             <input type="color" class="swatch__picker" data-token="--success-color" aria-label="Edit Success state" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--success-color</code>
             <span class="swatch__label">Success state</span>
-            <span class="swatch__value" data-value="--success-color">…</span>
+            <code class="swatch__value" data-value="--success-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -251,8 +263,9 @@
             <input type="color" class="swatch__picker" data-token="--button-text-color" aria-label="Edit Button text on accent backgrounds" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--button-text-color</code>
             <span class="swatch__label">Button text on accent backgrounds</span>
-            <span class="swatch__value" data-value="--button-text-color">…</span>
+            <code class="swatch__value" data-value="--button-text-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -260,8 +273,9 @@
             <input type="color" class="swatch__picker" data-token="--header-background" aria-label="Edit Site header background" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--header-background</code>
             <span class="swatch__label">Site header background</span>
-            <span class="swatch__value" data-value="--header-background">…</span>
+            <code class="swatch__value" data-value="--header-background">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -269,8 +283,9 @@
             <input type="color" class="swatch__picker" data-token="--header-text-color" aria-label="Edit Site header text" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--header-text-color</code>
             <span class="swatch__label">Site header text</span>
-            <span class="swatch__value" data-value="--header-text-color">…</span>
+            <code class="swatch__value" data-value="--header-text-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -278,8 +293,9 @@
             <input type="color" class="swatch__picker" data-token="--card-background" aria-label="Edit Card / surface background" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--card-background</code>
             <span class="swatch__label">Card / surface background</span>
-            <span class="swatch__value" data-value="--card-background">…</span>
+            <code class="swatch__value" data-value="--card-background">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -287,8 +303,9 @@
             <input type="color" class="swatch__picker" data-token="--muted-text" aria-label="Edit Secondary / muted text" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--muted-text</code>
             <span class="swatch__label">Secondary / muted text</span>
-            <span class="swatch__value" data-value="--muted-text">…</span>
+            <code class="swatch__value" data-value="--muted-text">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -296,8 +313,9 @@
             <input type="color" class="swatch__picker" data-token="--warning-color" aria-label="Edit Warning state" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--warning-color</code>
             <span class="swatch__label">Warning state</span>
-            <span class="swatch__value" data-value="--warning-color">…</span>
+            <code class="swatch__value" data-value="--warning-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -305,8 +323,9 @@
             <input type="color" class="swatch__picker" data-token="--info-color" aria-label="Edit Informational state" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--info-color</code>
             <span class="swatch__label">Informational state</span>
-            <span class="swatch__value" data-value="--info-color">…</span>
+            <code class="swatch__value" data-value="--info-color">…</code>
           </span>
         </div>
   </div>
@@ -318,8 +337,9 @@
             <input type="color" class="swatch__picker" data-token="--artist-badge-color" aria-label="Edit Artist role badge color" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--artist-badge-color</code>
             <span class="swatch__label">Artist role badge color</span>
-            <span class="swatch__value" data-value="--artist-badge-color">…</span>
+            <code class="swatch__value" data-value="--artist-badge-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -327,8 +347,9 @@
             <input type="color" class="swatch__picker" data-token="--team-badge-color" aria-label="Edit Team member role badge color" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--team-badge-color</code>
             <span class="swatch__label">Team member role badge color</span>
-            <span class="swatch__value" data-value="--team-badge-color">…</span>
+            <code class="swatch__value" data-value="--team-badge-color">…</code>
           </span>
         </div>
         <div class="swatch">
@@ -336,8 +357,9 @@
             <input type="color" class="swatch__picker" data-token="--professional-badge-color" aria-label="Edit Professional role badge color" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">--professional-badge-color</code>
             <span class="swatch__label">Professional role badge color</span>
-            <span class="swatch__value" data-value="--professional-badge-color">…</span>
+            <code class="swatch__value" data-value="--professional-badge-color">…</code>
           </span>
         </div>
   </div>
@@ -347,19 +369,31 @@
   <div class="fonts">
         <div class="font" style="font-family:var(--font-family-heading);">
           <span class="font__sample">Extra Chill — the Online Music Scene</span>
-          <span class="font__label">Headings</span>
+          <span class="font__meta">
+            <code class="font__token">--font-family-heading</code>
+            <span class="font__label">Headings</span>
+          </span>
         </div>
         <div class="font" style="font-family:var(--font-family-body);">
           <span class="font__sample">Extra Chill — the Online Music Scene</span>
-          <span class="font__label">Body text</span>
+          <span class="font__meta">
+            <code class="font__token">--font-family-body</code>
+            <span class="font__label">Body text</span>
+          </span>
         </div>
         <div class="font" style="font-family:var(--font-family-brand);">
           <span class="font__sample">Extra Chill</span>
-          <span class="font__label">Brand / logo text</span>
+          <span class="font__meta">
+            <code class="font__token">--font-family-brand</code>
+            <span class="font__label">Brand / logo text</span>
+          </span>
         </div>
         <div class="font" style="font-family:var(--font-family-mono);">
           <span class="font__sample">Extra Chill — the Online Music Scene</span>
-          <span class="font__label">Monospace / code</span>
+          <span class="font__meta">
+            <code class="font__token">--font-family-mono</code>
+            <span class="font__label">Monospace / code</span>
+          </span>
         </div>
   </div>
 
@@ -367,18 +401,22 @@
   <div class="weights">
         <div class="weight" style="font-weight:var(--font-weight-normal);">
           <span class="weight__sample">Extra Chill</span>
+          <code class="weight__token">--font-weight-normal</code>
           <span class="weight__label">Normal / body text</span>
         </div>
         <div class="weight" style="font-weight:var(--font-weight-medium);">
           <span class="weight__sample">Extra Chill</span>
+          <code class="weight__token">--font-weight-medium</code>
           <span class="weight__label">Medium emphasis</span>
         </div>
         <div class="weight" style="font-weight:var(--font-weight-semibold);">
           <span class="weight__sample">Extra Chill</span>
+          <code class="weight__token">--font-weight-semibold</code>
           <span class="weight__label">Labels, tab buttons, subheadings</span>
         </div>
         <div class="weight" style="font-weight:var(--font-weight-bold);">
           <span class="weight__sample">Extra Chill</span>
+          <code class="weight__token">--font-weight-bold</code>
           <span class="weight__label">Headings, strong emphasis</span>
         </div>
   </div>

--- a/scripts/build-design-system.js
+++ b/scripts/build-design-system.js
@@ -124,8 +124,9 @@ function colorSwatch( { token, desc } ) {
             <input type="color" class="swatch__picker" data-token="${ esc( token ) }" aria-label="Edit ${ esc( label ) }" />
           </label>
           <span class="swatch__meta">
+            <code class="swatch__token">${ esc( token ) }</code>
             <span class="swatch__label">${ esc( label ) }</span>
-            <span class="swatch__value" data-value="${ esc( token ) }">…</span>
+            <code class="swatch__value" data-value="${ esc( token ) }">…</code>
           </span>
         </div>`;
 }
@@ -135,7 +136,10 @@ function fontRow( { token, desc, isBrand } ) {
 	const label = desc || humanize( token );
 	return `        <div class="font" style="font-family:var(${ token });">
           <span class="font__sample">${ esc( sample ) }</span>
-          <span class="font__label">${ esc( label ) }</span>
+          <span class="font__meta">
+            <code class="font__token">${ esc( token ) }</code>
+            <span class="font__label">${ esc( label ) }</span>
+          </span>
         </div>`;
 }
 
@@ -143,6 +147,7 @@ function weightRow( { token, desc } ) {
 	const label = desc || humanize( token );
 	return `        <div class="weight" style="font-weight:var(${ token });">
           <span class="weight__sample">Extra Chill</span>
+          <code class="weight__token">${ esc( token ) }</code>
           <span class="weight__label">${ esc( label ) }</span>
         </div>`;
 }
@@ -257,7 +262,8 @@ const html = `<!DOCTYPE html>
     opacity: 0; cursor: pointer;
   }
   .swatch__meta { display: flex; flex-direction: column; gap: var(--spacing-xs); min-width: 0; }
-  .swatch__label, .font__label, .weight__label { font-size: var(--font-size-sm); }
+  .swatch__token, .font__token, .weight__token { color: var(--link-color); word-break: break-all; }
+  .swatch__label, .font__label, .weight__label { font-size: var(--font-size-sm); color: var(--muted-text); }
   .swatch__value { font-size: var(--font-size-xs); color: var(--muted-text); }
 
   .fonts { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--spacing-md); }
@@ -268,7 +274,7 @@ const html = `<!DOCTYPE html>
     padding: var(--spacing-md);
   }
   .font__sample { display: block; font-size: var(--font-size-xl); margin-bottom: var(--spacing-sm); }
-  .font__label { color: var(--muted-text); }
+  .font__meta { display: flex; flex-direction: column; gap: var(--spacing-xs); }
 
   .weights { display: flex; flex-wrap: wrap; gap: var(--spacing-lg); }
   .weight { display: flex; flex-direction: column; gap: var(--spacing-xs); }


### PR DESCRIPTION
## Summary

Follow-up to #55. That copy pass over-removed — it stripped the per-swatch **token names** along with the intro jargon. Only the intro's package / `root.css` references were meant to go.

This restores, on each color swatch, font, and weight:
- the **variable name** (e.g. `--background-color`),
- the **human description** (e.g. "Page background"),
- the **live value**.

The intro stays free of package names and `root.css` (unchanged from #55).

## URL

`https://extrachill.com/wp-content/themes/extrachill/design-system.html`

## Verification

- `node --check` on the generator + extracted inline script — parse clean.
- `npm run build` regenerates the page; confirmed swatches now show `--token` + description + value, and the intro still has **0** `@extrachill/tokens` / `root.css` references.
- `homeboy lint extrachill --file scripts/build-design-system.js` — passes clean.

No `CHANGELOG.md` or version-string edits.