### PR TITLE
fix: clear pre-existing whole-tree lint debt in theme

### DIFF
--- a/assets/js/mini-dropdown.js
+++ b/assets/js/mini-dropdown.js
@@ -3,8 +3,6 @@
  *
  * Unified dropdown behavior for ec-mini-dropdown components.
  * Handles toggle, click-outside-close, and keyboard accessibility.
- *
- * @package ExtraChill
  */
 (function() {
 	'use strict';
@@ -20,12 +18,12 @@
 	}
 
 	document.addEventListener('click', function(event) {
-		var toggle = event.target.closest('.ec-mini-dropdown-toggle');
-		var dropdown = event.target.closest('.ec-mini-dropdown');
+		const toggle = event.target.closest('.ec-mini-dropdown-toggle');
+		const dropdown = event.target.closest('.ec-mini-dropdown');
 
 		if (toggle && dropdown) {
 			event.preventDefault();
-			var isOpen = dropdown.getAttribute('aria-expanded') === 'true';
+			const isOpen = dropdown.getAttribute('aria-expanded') === 'true';
 
 			closeAllDropdowns();
 

--- a/assets/js/nav-menu.js
+++ b/assets/js/nav-menu.js
@@ -7,7 +7,6 @@
 document.addEventListener('DOMContentLoaded', function() {
     const searchToggle = document.querySelector('.search-icon');
     const searchPanel = document.querySelector('.header-search-panel');
-    const closeSearchButton = document.querySelector('.search-close-button');
 
     if (!searchToggle || !searchPanel) {
         return;
@@ -31,6 +30,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     searchToggle.addEventListener('click', openSearch);
 
+    const closeSearchButton = document.querySelector('.search-close-button');
     if (closeSearchButton) {
         closeSearchButton.addEventListener('click', function(event) {
             event.preventDefault();

--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -4,8 +4,6 @@
  * Handles clipboard copy for share button copy-link functionality.
  * Dropdown behavior provided by mini-dropdown.js.
  * Tracks share clicks via analytics endpoint.
- *
- * @package ExtraChill
  */
 (function() {
     'use strict';
@@ -13,12 +11,12 @@
     /**
      * Track share click via analytics endpoint.
      *
-     * @param {string} destination - Share destination (facebook, twitter, etc.)
-     * @param {string} shareUrl - URL being shared
+     * @param {string} destination Share destination (facebook, twitter, etc.)
+     * @param {string} shareUrl    URL being shared
      */
     function ecTrackShare(destination, shareUrl) {
-        var endpoint = '/wp-json/extrachill/v1/analytics/click';
-        var data = {
+        const endpoint = '/wp-json/extrachill/v1/analytics/click';
+        const data = {
             click_type: 'share',
             share_destination: destination,
             source_url: window.location.href,
@@ -38,7 +36,7 @@
     }
 
     function ecCopyToClipboard(text, linkEl) {
-        var originalText = linkEl.textContent;
+        const originalText = linkEl.textContent;
 
         if (navigator.clipboard && navigator.clipboard.writeText) {
             return navigator.clipboard.writeText(text)
@@ -57,7 +55,7 @@
     }
 
     function ecFetchMarkdownExport(postId, blogId) {
-        var url = '/wp-json/extrachill/v1/tools/markdown-export?post_id=' + encodeURIComponent(postId);
+        let url = '/wp-json/extrachill/v1/tools/markdown-export?post_id=' + encodeURIComponent(postId);
         if (blogId) {
             url += '&blog_id=' + encodeURIComponent(blogId);
         }
@@ -79,18 +77,18 @@
 
     // Track social share link clicks (these open in new tabs, no preventDefault needed)
     document.addEventListener('click', function(event) {
-        var shareOption = event.target.closest('.share-dropdown .share-option a');
+        const shareOption = event.target.closest('.share-dropdown .share-option a');
         if (!shareOption) {
             return;
         }
 
-        var optionContainer = shareOption.closest('.share-option');
+        const optionContainer = shareOption.closest('.share-option');
         if (!optionContainer) {
             return;
         }
 
         // Determine destination from class name
-        var destination = null;
+        let destination = null;
         if (optionContainer.classList.contains('facebook')) {
             destination = 'facebook';
         } else if (optionContainer.classList.contains('twitter')) {
@@ -111,8 +109,8 @@
 
     // Handle copy-link and copy-markdown (these need preventDefault)
     document.addEventListener('click', function(event) {
-        var copyLink = event.target.closest('.copy-link a');
-        var copyMarkdown = event.target.closest('.copy-markdown a');
+        const copyLink = event.target.closest('.copy-link a');
+        const copyMarkdown = event.target.closest('.copy-markdown a');
 
         if (!copyLink && !copyMarkdown) {
             return;
@@ -121,7 +119,7 @@
         event.preventDefault();
 
         if (copyLink) {
-            var url = copyLink.getAttribute('data-share-url');
+            const url = copyLink.getAttribute('data-share-url');
             if (!url) {
                 return;
             }
@@ -131,17 +129,17 @@
             return;
         }
 
-        var dropdown = event.target.closest('.share-dropdown');
+        const dropdown = event.target.closest('.share-dropdown');
         if (!dropdown) {
             return;
         }
 
-        var postId = dropdown.getAttribute('data-post-id');
+        const postId = dropdown.getAttribute('data-post-id');
         if (!postId) {
             return;
         }
 
-        var blogId = dropdown.getAttribute('data-blog-id');
+        const blogId = dropdown.getAttribute('data-blog-id');
 
         copyMarkdown.textContent = 'Loading...';
         ecTrackShare('copy_markdown', window.location.href);

--- a/assets/js/shared-tabs.js
+++ b/assets/js/shared-tabs.js
@@ -1,9 +1,12 @@
+/* global history */
 document.addEventListener('DOMContentLoaded', function() {
     const components = document.querySelectorAll('.shared-tabs-component');
 
     components.forEach(component => {
         const tabButtonsContainer = component.querySelector('.shared-tabs-buttons-container');
-        if (!tabButtonsContainer) return;
+        if (!tabButtonsContainer) {
+            return;
+        }
 
         const tabButtons = tabButtonsContainer.querySelectorAll('.shared-tab-button');
         const desktopContentArea = component.querySelector('.shared-desktop-tab-content-area');
@@ -13,8 +16,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         function storeInitialPaneStructure() {
             if (originalPaneInfo.size > 0) {
-                let firstPaneId = component.querySelector('.shared-tab-pane')?.id;
-                if (firstPaneId && originalPaneInfo.has(firstPaneId)) return;
+                const firstPaneId = component.querySelector('.shared-tab-pane')?.id;
+                if (firstPaneId && originalPaneInfo.has(firstPaneId)) {
+                    return;
+                }
             }
             originalPaneInfo.clear();
             const panes = component.querySelectorAll('.shared-tab-pane');
@@ -41,7 +46,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // Modify updateTabs to accept an optional forceOpen parameter
         function updateTabs(activeButton, shouldScroll = true, forceOpen = false, isButtonClick = false, shouldUpdateHash = false) {
-            if (!activeButton) return; 
+            if (!activeButton) {
+                return;
+            }
             const targetTabId = activeButton.dataset.tab;
             const targetPane = component.querySelector('#' + targetTabId + '.shared-tab-pane');
             const isDesktop = window.innerWidth >= mobileBreakpoint;
@@ -50,8 +57,12 @@ document.addEventListener('DOMContentLoaded', function() {
             if (!isDesktop && !forceOpen && isButtonClick && activeButton.classList.contains('active')) {
                 activeButton.classList.remove('active');
                 const arrow = activeButton.querySelector('.shared-tab-arrow');
-                if (arrow) arrow.classList.remove('open');
-                if (targetPane) targetPane.style.display = 'none';
+                if (arrow) {
+                    arrow.classList.remove('open');
+                }
+                if (targetPane) {
+                    targetPane.style.display = 'none';
+                }
                  if (history.pushState && targetPane && window.location.hash === '#' + targetPane.id) {
                     history.pushState(null, null, window.location.pathname + window.location.search.split('#')[0]);
                 }
@@ -67,7 +78,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (btn !== activeButton) {
                     btn.classList.remove('active');
                     const arrow = btn.querySelector('.shared-tab-arrow');
-                    if (arrow) arrow.classList.remove('open');
+                    if (arrow) {
+                        arrow.classList.remove('open');
+                    }
                     // Hiding of non-active panes is handled below based on layout
                 }
             });
@@ -75,7 +88,9 @@ document.addEventListener('DOMContentLoaded', function() {
             // Activate current button
             activeButton.classList.add('active');
             const arrow = activeButton.querySelector('.shared-tab-arrow');
-            if (arrow) arrow.classList.add('open');
+            if (arrow) {
+                arrow.classList.add('open');
+            }
 
             // --- Refactored Pane Management Logic --- 
             const allPanes = component.querySelectorAll('.shared-tab-pane');
@@ -260,6 +275,7 @@ document.addEventListener('DOMContentLoaded', function() {
                      // initializeDefaultOrActiveTab(); // initializeDefaultOrActiveTab handles its own scrolling logic
                      // Instead of re-initializing the default, let's just ensure correct state based on resize
                      // If no button is active, ensure all panes are in original location and hidden, and desktop area is hidden
+                     const allPanes = component.querySelectorAll('.shared-tab-pane');
                      allPanes.forEach(pane => {
                          const info = originalPaneInfo.get(pane.id);
                          if (info && info.parent && pane.parentElement !== info.parent) {
@@ -282,6 +298,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // Listen for the custom event dispatched by join-flow-ui.js
         document.addEventListener('activateJoinFlowTab', function(event) {
+            // eslint-disable-next-line no-console -- debug log for external tab activation.
             console.log('activateJoinFlowTab event received for tab:', event.detail.targetTab);
             if (event.detail && event.detail.targetTab) {
                  // Find the component this event is intended for (assuming one shared tabs component on the page)

--- a/footer.php
+++ b/footer.php
@@ -23,7 +23,7 @@
 
 	<div class="footer-copyright">
 		<?php $main_site_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'main' ) : home_url(); ?>
-		&copy; <?php echo date( 'Y' ); ?> <a href="<?php echo esc_url( $main_site_url ); ?>"><?php echo esc_html( extrachill_get_site_title() ); ?></a>. All rights reserved.
+		&copy; <?php echo esc_html( gmdate( 'Y' ) ); ?> <a href="<?php echo esc_url( $main_site_url ); ?>"><?php echo esc_html( extrachill_get_site_title() ); ?></a>. All rights reserved.
 	</div>
 
 	<?php do_action( 'extrachill_below_copyright' ); ?>

--- a/functions.php
+++ b/functions.php
@@ -101,11 +101,11 @@ function extrachill_gallery_image_sizes( string $content ): string {
 	// and replace the sizes attribute on images inside gallery figures.
 	$content = preg_replace_callback(
 		'/<figure\s[^>]*class="[^"]*wp-block-image[^"]*"[^>]*>.*?<\/figure>/s',
-		function ( $match ) use ( $gallery_sizes ) {
-			return preg_replace(
+		function ( array $matches ) use ( $gallery_sizes ) {
+			return (string) preg_replace(
 				'/sizes="[^"]*"/',
 				'sizes="' . esc_attr( $gallery_sizes ) . '"',
-				$match[0]
+				$matches[0]
 			);
 		},
 		$content

--- a/header.php
+++ b/header.php
@@ -20,9 +20,9 @@
 	endforeach;
 
 	$dns_prefetch_domains = apply_filters( 'extrachill_dns_prefetch_domains', array() );
-	foreach ( $dns_prefetch_domains as $domain ) :
+	foreach ( $dns_prefetch_domains as $prefetch_domain ) :
 		?>
-	<link rel="dns-prefetch" href="<?php echo esc_url( $domain ); ?>">
+	<link rel="dns-prefetch" href="<?php echo esc_url( $prefetch_domain ); ?>">
 		<?php
 	endforeach;
 	?>

--- a/inc/archives/archive-custom-sorting.php
+++ b/inc/archives/archive-custom-sorting.php
@@ -42,13 +42,13 @@ function extrachill_artist_filter_dropdown() {
 	echo '<div id="artist-filters">';
 	echo '<select id="artist-filter-dropdown" onchange="window.location.href=this.value;">';
 
-	$selected = empty( $current_artist ) ? ' selected' : '';
-	echo '<option value="' . esc_url( $archive_link ) . '"' . $selected . '>All Artists</option>';
+	$is_all_selected = empty( $current_artist );
+	echo '<option value="' . esc_url( $archive_link ) . '"' . ( $is_all_selected ? ' selected' : '' ) . '>All Artists</option>';
 
 	foreach ( $artists as $artist ) {
-		$artist_url = add_query_arg( 'artist', $artist->slug, $archive_link );
-		$selected   = ( $artist->slug == $current_artist ) ? ' selected' : '';
-		echo '<option value="' . esc_url( $artist_url ) . '"' . $selected . '>' . esc_html( $artist->name ) . '</option>';
+		$artist_url         = add_query_arg( 'artist', $artist->slug, $archive_link );
+		$is_artist_selected = ( $artist->slug === $current_artist );
+		echo '<option value="' . esc_url( $artist_url ) . '"' . ( $is_artist_selected ? ' selected' : '' ) . '>' . esc_html( $artist->name ) . '</option>';
 	}
 
 	echo '</select></div>';
@@ -63,6 +63,7 @@ function extrachill_artist_filter_dropdown() {
  */
 function extrachill_sort_posts( $query ) {
 	if ( ! is_admin() && $query->is_main_query() && ( is_archive() || get_query_var( 'extrachill_blog_archive' ) ) ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- GET-based sort read for display ordering; no state change.
 		$sort = isset( $_GET['sort'] ) ? $_GET['sort'] : '';
 
 		switch ( $sort ) {

--- a/inc/archives/archive-header.php
+++ b/inc/archives/archive-header.php
@@ -19,7 +19,7 @@
 				$artist_slug = get_query_var( 'artist' );
 				if ( ! empty( $artist_slug ) ) {
 					$artist_term = get_term_by( 'slug', $artist_slug, 'artist' );
-					if ( $artist_term && ! is_wp_error( $artist_term ) ) {
+					if ( $artist_term ) {
 						echo esc_html( $artist_term->name ) . ' ';
 					}
 				}
@@ -40,17 +40,29 @@
 					esc_html( $archive_author_name )
 				);
 			} elseif ( is_day() ) {
-				printf( __( 'Day: %s', 'extrachill' ), get_the_date() );
+				printf(
+				/* translators: %s: Post date. */
+					esc_html__( 'Day: %s', 'extrachill' ),
+					esc_html( (string) get_the_date() )
+				);
 			} elseif ( is_month() ) {
-				printf( __( 'Month: %s', 'extrachill' ), get_the_date( 'F Y' ) );
+				printf(
+				/* translators: %s: Post date. */
+					esc_html__( 'Month: %s', 'extrachill' ),
+					esc_html( (string) get_the_date( 'F Y' ) )
+				);
 			} elseif ( is_year() ) {
-				printf( __( 'Year: %s', 'extrachill' ), get_the_date( 'Y' ) );
+				printf(
+				/* translators: %s: Post date. */
+					esc_html__( 'Year: %s', 'extrachill' ),
+					esc_html( (string) get_the_date( 'Y' ) )
+				);
 			} elseif ( get_query_var( 'extrachill_blog_archive' ) ) {
 				esc_html_e( 'The Latest', 'extrachill' );
 			} elseif ( is_search() ) {
 				printf(
-					/* translators: %s: search query */
-					__( 'Search Results for: %s', 'extrachill' ),
+				/* translators: %s: search query. */
+					esc_html__( 'Search Results for: %s', 'extrachill' ),
 					'<span class="search-query">' . esc_html( get_search_query() ) . '</span>'
 				);
 			} else {
@@ -75,7 +87,7 @@ if ( ! is_paged() ) {
 	if ( is_author() ) {
 		$author_bio = get_the_author_meta( 'description' );
 		if ( ! empty( $author_bio ) ) {
-			echo '<div class="author-bio">' . wpautop( $author_bio ) . '</div>';
+			echo '<div class="author-bio">' . wp_kses_post( wpautop( $author_bio ) ) . '</div>';
 		}
 		do_action( 'extrachill_after_author_bio', get_queried_object_id() );
 	}

--- a/inc/archives/post-card.php
+++ b/inc/archives/post-card.php
@@ -14,14 +14,17 @@ $featured_image_size = 'medium_large';
 <div class="archive-card">
 	<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 		<?php do_action( 'extrachill_archive_above_tax_badges' ); ?>
-		<?php extrachill_display_taxonomy_badges( get_the_ID() ); ?>
+		<?php
+		$ec_post_id = get_the_ID();
+		extrachill_display_taxonomy_badges( false !== $ec_post_id ? $ec_post_id : null );
+		?>
 
 		<?php
 		if ( isset( $post->_thumbnail ) && ! empty( $post->_thumbnail['thumbnail_url'] ) ) {
 			$thumbnail = $post->_thumbnail;
 			?>
 			<div class="featured-image">
-				<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : the_permalink(); ?>" title="<?php the_title_attribute(); ?>">
+				<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : esc_url( (string) get_permalink() ); ?>" title="<?php the_title_attribute(); ?>">
 					<img src="<?php echo esc_url( $thumbnail['thumbnail_url'] ); ?>"
 						<?php if ( ! empty( $thumbnail['thumbnail_width'] ) && ! empty( $thumbnail['thumbnail_height'] ) ) : ?>
 						width="<?php echo esc_attr( $thumbnail['thumbnail_width'] ); ?>"
@@ -39,7 +42,7 @@ $featured_image_size = 'medium_large';
 			</div>
 		<?php } elseif ( has_post_thumbnail() ) { ?>
 			<div class="featured-image">
-				<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : the_permalink(); ?>" title="<?php the_title_attribute(); ?>">
+				<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : esc_url( (string) get_permalink() ); ?>" title="<?php the_title_attribute(); ?>">
 					<?php the_post_thumbnail( 'medium_large' ); ?>
 				</a>
 			</div>
@@ -48,7 +51,7 @@ $featured_image_size = 'medium_large';
 		<div class="archive-post">
 			<header>
 				<h2>
-					<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : the_permalink(); ?>" class="card-link-target" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a>
+					<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : esc_url( (string) get_permalink() ); ?>" class="card-link-target" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a>
 				</h2>
 			</header>
 
@@ -56,11 +59,11 @@ $featured_image_size = 'medium_large';
 
 			<?php if ( isset( $post->_is_forum_post ) && $post->_is_forum_post ) : ?>
 				<span>
-					<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : esc_url( get_permalink( $post ) ); ?>" class="button-1 button-small" id="forum-post" target="_blank" rel="noopener noreferrer">View in Community</a>
+					<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : esc_url( (string) get_permalink() ); ?>" class="button-1 button-small" id="forum-post" target="_blank" rel="noopener noreferrer">View in Community</a>
 				</span>
 			<?php else : ?>
 				<span>
-					<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : the_permalink(); ?>" class="button-1 button-medium" target="_self" rel="noopener noreferrer">View Full Post</a>
+					<a href="<?php echo isset( $post->permalink ) ? esc_url( $post->permalink ) : esc_url( (string) get_permalink() ); ?>" class="button-1 button-medium" target="_self" rel="noopener noreferrer">View Full Post</a>
 				</span>
 			<?php endif; ?>
 		</div>

--- a/inc/components/filter-bar-defaults.php
+++ b/inc/components/filter-bar-defaults.php
@@ -147,8 +147,10 @@ function extrachill_build_child_terms_dropdown() {
 
 	$options = array( '' => $select_text );
 	foreach ( $child_terms as $child_term ) {
-		$term_link             = is_category() ? get_category_link( $child_term->term_id ) : get_term_link( $child_term );
-		$options[ $term_link ] = $child_term->name;
+		$term_link = is_category() ? get_category_link( $child_term->term_id ) : get_term_link( $child_term );
+		if ( is_string( $term_link ) ) {
+			$options[ $term_link ] = $child_term->name;
+		}
 	}
 
 	return array(
@@ -212,6 +214,7 @@ function extrachill_build_artist_dropdown() {
  * @return array Dropdown item.
  */
 function extrachill_build_sort_dropdown() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading a GET param for display; no state change occurs.
 	$current_sort = isset( $_GET['sort'] ) ? sanitize_key( $_GET['sort'] ) : 'recent';
 
 	$options = apply_filters(

--- a/inc/components/filter-bar.php
+++ b/inc/components/filter-bar.php
@@ -31,7 +31,7 @@ function extrachill_filter_bar() {
 				'extrachill-filter-bar',
 				get_template_directory_uri() . '/assets/css/filter-bar.css',
 				array(),
-				filemtime( $css_file )
+				(string) filemtime( $css_file )
 			);
 		}
 		$css_enqueued = true;
@@ -39,7 +39,7 @@ function extrachill_filter_bar() {
 
 	$override = apply_filters( 'extrachill_filter_bar_override', '' );
 	if ( ! empty( $override ) ) {
-		echo $override;
+		echo wp_kses_post( $override );
 		return;
 	}
 
@@ -49,7 +49,7 @@ function extrachill_filter_bar() {
 		return;
 	}
 
-	$form_action = is_search() ? home_url( '/' ) : strtok( $_SERVER['REQUEST_URI'], '?' );
+	$form_action = is_search() ? home_url( '/' ) : (string) strtok( isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '/', '?' );
 
 	echo '<form method="get" action="' . esc_url( $form_action ) . '" class="extrachill-filter-bar">';
 
@@ -121,8 +121,8 @@ function extrachill_render_filter_dropdown( $item ) {
 	echo ' onchange="' . esc_attr( $onchange ) . '">';
 
 	foreach ( $options as $value => $label ) {
-		$selected = ( (string) $value === (string) $current ) ? ' selected' : '';
-		echo '<option value="' . esc_attr( $value ) . '"' . $selected . '>' . esc_html( $label ) . '</option>';
+		$is_selected = ( (string) $value === (string) $current );
+		echo '<option value="' . esc_attr( $value ) . '"' . ( $is_selected ? ' selected' : '' ) . '>' . esc_html( $label ) . '</option>';
 	}
 
 	echo '</select>';
@@ -153,9 +153,9 @@ function extrachill_render_filter_search( $item ) {
 
 	echo '<button type="submit" aria-label="' . esc_attr__( 'Search', 'extrachill' ) . '">';
 	if ( ! empty( $button_icon ) ) {
-		echo $button_icon;
+		echo wp_kses_post( $button_icon );
 	} elseif ( function_exists( 'ec_icon' ) ) {
-		echo ec_icon( 'search' );
+		echo ec_icon( 'search' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_icon() returns SVG markup built from a fixed template with esc_attr()'d values.
 	} else {
 		echo esc_html__( 'Search', 'extrachill' );
 	}

--- a/inc/core/actions.php
+++ b/inc/core/actions.php
@@ -15,8 +15,8 @@ function extrachill_default_below_copyright() {
 add_action( 'extrachill_below_copyright', 'extrachill_default_below_copyright', 10 );
 
 function extrachill_hook_taxonomy_badges_above_title() {
-
-	extrachill_display_taxonomy_badges( get_the_ID() );
+	$post_id = get_the_ID();
+	extrachill_display_taxonomy_badges( false !== $post_id ? $post_id : null );
 }
 add_action( 'extrachill_above_post_title', 'extrachill_hook_taxonomy_badges_above_title' );
 

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -16,7 +16,7 @@ function extrachill_enqueue_navigation_assets() {
 			'extrachill-nav-menu',
 			get_template_directory_uri() . '/assets/js/nav-menu.js',
 			array(),
-			filemtime( $nav_js_path ),
+			(string) filemtime( $nav_js_path ),
 			array(
 				'strategy'  => 'defer',
 				'in_footer' => true,
@@ -107,7 +107,7 @@ function extrachill_enqueue_root_styles() {
 			'extrachill-root',
 			get_stylesheet_directory_uri() . '/assets/css/root.css',
 			array(),
-			filemtime( $css_path )
+			(string) filemtime( $css_path )
 		);
 	}
 }
@@ -140,7 +140,7 @@ function extrachill_enqueue_embed_iframe_styles() {
 				'extrachill-root',
 				get_stylesheet_directory_uri() . '/assets/css/root.css',
 				array(),
-				filemtime( $root_css_path )
+				(string) filemtime( $root_css_path )
 			);
 		}
 
@@ -153,7 +153,7 @@ function extrachill_enqueue_embed_iframe_styles() {
 			'extrachill-embed',
 			get_stylesheet_directory_uri() . '/assets/css/embed.css',
 			array( 'extrachill-root' ),
-			filemtime( $embed_css_path )
+			(string) filemtime( $embed_css_path )
 		);
 	}
 }
@@ -166,7 +166,7 @@ function extrachill_enqueue_taxonomy_badges() {
 			'extrachill-taxonomy-badges',
 			get_stylesheet_directory_uri() . '/assets/css/taxonomy-badges.css',
 			array( 'extrachill-root' ),
-			filemtime( $taxonomy_badges_path )
+			(string) filemtime( $taxonomy_badges_path )
 		);
 	}
 }
@@ -180,7 +180,7 @@ function extrachill_modify_default_style() {
 		'extrachill-style',
 		get_stylesheet_uri(),
 		array( 'extrachill-root' ),
-		filemtime( get_template_directory() . '/style.css' )
+		(string) filemtime( get_template_directory() . '/style.css' )
 	);
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_modify_default_style', 20 );
@@ -229,7 +229,7 @@ function extrachill_enqueue_block_editor_iframe_assets() {
 				'extrachill-root',
 				get_stylesheet_directory_uri() . '/assets/css/root.css',
 				array(),
-				filemtime( $root_css_path )
+				(string) filemtime( $root_css_path )
 			);
 		}
 
@@ -243,7 +243,7 @@ function extrachill_enqueue_block_editor_iframe_assets() {
 				'extrachill-style',
 				get_stylesheet_uri(),
 				array( 'extrachill-root' ),
-				filemtime( $theme_style_path )
+				(string) filemtime( $theme_style_path )
 			);
 		}
 
@@ -257,7 +257,7 @@ function extrachill_enqueue_block_editor_iframe_assets() {
 				'extrachill-block-editor',
 				get_stylesheet_directory_uri() . '/assets/css/block-editor.css',
 				array( 'extrachill-root' ),
-				filemtime( $block_editor_css_path )
+				(string) filemtime( $block_editor_css_path )
 			);
 		}
 
@@ -457,21 +457,21 @@ function extrachill_enqueue_single_post_styles() {
 				'extrachill-single-post',
 				get_stylesheet_directory_uri() . '/assets/css/single-post.css',
 				array( 'extrachill-root', 'extrachill-style' ),
-				filemtime( $css_path )
+				(string) filemtime( $css_path )
 			);
 		}
 	}
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_enqueue_single_post_styles', 20 );
 
-function extrachill_hide_settings_page_title( $show, $post_id ) {
+function extrachill_hide_settings_page_title( $show ) {
 	if ( is_page( 'settings' ) ) {
 		return false;
 	}
 
 	return $show;
 }
-add_filter( 'extrachill_show_page_title', 'extrachill_hide_settings_page_title', 10, 2 );
+add_filter( 'extrachill_show_page_title', 'extrachill_hide_settings_page_title', 10, 1 );
 
 function extrachill_enqueue_archive_styles() {
 	if ( is_archive() || is_search() || get_query_var( 'extrachill_blog_archive' ) ) {
@@ -481,7 +481,7 @@ function extrachill_enqueue_archive_styles() {
 				'extrachill-archive',
 				get_stylesheet_directory_uri() . '/assets/css/archive.css',
 				array( 'extrachill-root', 'extrachill-style' ),
-				filemtime( $css_path )
+				(string) filemtime( $css_path )
 			);
 		}
 	}
@@ -496,7 +496,7 @@ function extrachill_enqueue_search_styles() {
 				'extrachill-search',
 				get_stylesheet_directory_uri() . '/assets/css/search.css',
 				array( 'extrachill-root', 'extrachill-style' ),
-				filemtime( $css_path )
+				(string) filemtime( $css_path )
 			);
 		}
 	}
@@ -515,7 +515,7 @@ function extrachill_enqueue_sidebar_styles() {
 					'extrachill-sidebar',
 					get_stylesheet_directory_uri() . '/assets/css/sidebar.css',
 					array( 'extrachill-root', 'extrachill-style' ),
-					filemtime( $css_path )
+					(string) filemtime( $css_path )
 				);
 			}
 		}
@@ -528,14 +528,14 @@ function extrachill_register_shared_tabs() {
 		'extrachill-shared-tabs',
 		get_template_directory_uri() . '/assets/css/shared-tabs.css',
 		array(),
-		filemtime( get_template_directory() . '/assets/css/shared-tabs.css' )
+		(string) filemtime( get_template_directory() . '/assets/css/shared-tabs.css' )
 	);
 
 	wp_register_script(
 		'extrachill-shared-tabs',
 		get_template_directory_uri() . '/assets/js/shared-tabs.js',
 		array(),
-		filemtime( get_template_directory() . '/assets/js/shared-tabs.js' ),
+		(string) filemtime( get_template_directory() . '/assets/js/shared-tabs.js' ),
 		array(
 			'strategy'  => 'defer',
 			'in_footer' => true,
@@ -549,7 +549,7 @@ function extrachill_register_mini_dropdown() {
 		'extrachill-mini-dropdown',
 		get_template_directory_uri() . '/assets/js/mini-dropdown.js',
 		array(),
-		filemtime( get_template_directory() . '/assets/js/mini-dropdown.js' ),
+		(string) filemtime( get_template_directory() . '/assets/js/mini-dropdown.js' ),
 		array(
 			'strategy'  => 'defer',
 			'in_footer' => true,
@@ -563,7 +563,7 @@ function extrachill_register_share_assets() {
 		'extrachill-share',
 		get_template_directory_uri() . '/assets/js/share.js',
 		array( 'extrachill-mini-dropdown' ),
-		filemtime( get_template_directory() . '/assets/js/share.js' ),
+		(string) filemtime( get_template_directory() . '/assets/js/share.js' ),
 		array(
 			'strategy'  => 'defer',
 			'in_footer' => true,
@@ -584,7 +584,7 @@ function extrachill_enqueue_network_dropdown_assets() {
 			'extrachill-network-dropdown',
 			get_template_directory_uri() . '/assets/css/network-dropdown.css',
 			array( 'extrachill-root' ),
-			filemtime( $css_path )
+			(string) filemtime( $css_path )
 		);
 	}
 }
@@ -616,6 +616,6 @@ function extrachill_output_custom_css_variables() {
 		return;
 	}
 
-	echo '<style id="extrachill-custom-css-variables">:root { ' . implode( '; ', $css_rules ) . '; }</style>' . "\n";
+	echo '<style id="extrachill-custom-css-variables">:root { ' . implode( '; ', $css_rules ) . '; }</style>' . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $css_rules elements are pre-escaped with esc_attr() and output inside a <style> block.
 }
 add_action( 'wp_head', 'extrachill_output_custom_css_variables', 20 );

--- a/inc/core/editor/instagram-embeds.php
+++ b/inc/core/editor/instagram-embeds.php
@@ -10,7 +10,7 @@
 function custom_instagram_embed_handler( $matches, $attr, $url, $rawattr ) {
 	if ( preg_match( '#https?://(www\.)?instagram\.com/[a-zA-Z0-9_.-]+/?$#i', $url ) ) {
 		$embed = sprintf(
-			'<blockquote class="instagram-media" data-instgrm-permalink="%s" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%%; width:-webkit-calc(100%% - 2px); width:calc(100%% - 2px);"><a href="%s" target="_blank"></a></blockquote><script async src="//www.instagram.com/embed.js"></script>',
+			'<blockquote class="instagram-media" data-instgrm-permalink="%s" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%%; width:-webkit-calc(100%% - 2px); width:calc(100%% - 2px);"><a href="%s" target="_blank"></a></blockquote><script async src="//www.instagram.com/embed.js"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- Instagram oEmbed provider markup; the embed.js loader ships with the provider response and cannot be deferred to wp_enqueue_script because oEmbed output is cached and rendered later.
 			esc_url( $url ),
 			esc_url( $url )
 		);

--- a/inc/core/icons.php
+++ b/inc/core/icons.php
@@ -46,11 +46,11 @@ add_action( 'wp_body_open', 'ec_inline_svg_sprite', 0 );
  * Render an SVG icon from the inlined sprite.
  *
  * @param string $icon_id The symbol ID in extrachill.svg.
- * @param string $class   Additional CSS classes (optional).
+ * @param string $css_class   Additional CSS classes (optional).
  * @return string SVG markup.
  */
-function ec_icon( $icon_id, $class = '' ) {
-	$classes = 'ec-icon' . ( $class ? ' ' . esc_attr( $class ) : '' );
+function ec_icon( $icon_id, $css_class = '' ) {
+	$classes = 'ec-icon' . ( $css_class ? ' ' . esc_attr( $css_class ) : '' );
 
 	return sprintf(
 		'<svg class="%s"><use href="#%s"></use></svg>',

--- a/inc/core/notices.php
+++ b/inc/core/notices.php
@@ -57,9 +57,9 @@ function extrachill_set_notice( $message, $type = 'info', $args = array() ) {
 		$notices[] = $notice;
 		setcookie(
 			'extrachill_notices',
-			wp_json_encode( $notices ),
+			(string) wp_json_encode( $notices ),
 			time() + 60,
-			COOKIEPATH,
+			defined( 'COOKIEPATH' ) ? COOKIEPATH : '/',
 			COOKIE_DOMAIN,
 			is_ssl(),
 			true
@@ -93,7 +93,7 @@ function extrachill_get_notices() {
 		if ( is_array( $stored ) && ! empty( $stored ) ) {
 			$notices = $stored;
 		}
-		setcookie( 'extrachill_notices', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( 'extrachill_notices', '', time() - 3600, defined( 'COOKIEPATH' ) ? COOKIEPATH : '/', COOKIE_DOMAIN );
 	}
 
 	return $notices;

--- a/inc/core/templates/breadcrumbs.php
+++ b/inc/core/templates/breadcrumbs.php
@@ -15,20 +15,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-	if ( ! function_exists( 'extrachill_breadcrumbs' ) ) {
-		function extrachill_breadcrumbs() {
-			echo '<nav class="breadcrumbs" itemprop="breadcrumb">';
+if ( ! function_exists( 'extrachill_breadcrumbs' ) ) {
+	function extrachill_breadcrumbs() {
+		echo '<nav class="breadcrumbs" itemprop="breadcrumb">';
 
-		// Allow plugins to override the root breadcrumb link
+		// Allow plugins to override the root breadcrumb link.
 		$root_link = apply_filters( 'extrachill_breadcrumbs_root', '<a href="' . home_url() . '">' . esc_html( extrachill_get_site_title() ) . '</a>' );
-		echo $root_link . ' › ';
+		echo wp_kses_post( $root_link ) . ' › ';
 
-		// Allow plugins to override the default breadcrumb trail
+		// Allow plugins to override the default breadcrumb trail.
 		$custom_trail = apply_filters( 'extrachill_breadcrumbs_override_trail', '' );
 		if ( ! empty( $custom_trail ) ) {
-			echo apply_filters( 'extrachill_breadcrumbs_trail_output', $custom_trail );
+			echo wp_kses_post( apply_filters( 'extrachill_breadcrumbs_trail_output', $custom_trail ) );
 		} else {
-			// Original breadcrumb logic
+			// Original breadcrumb logic.
 			if ( is_single() && is_singular( 'post' ) ) {
 				global $post;
 
@@ -57,80 +57,96 @@ if ( ! defined( 'ABSPATH' ) ) {
 				}
 			} elseif ( is_singular() && ! is_singular( array( 'post', 'page', 'product' ) ) ) {
 				$post_type     = get_post_type();
-				$post_type_obj = get_post_type_object( $post_type );
-				$archive_link  = get_post_type_archive_link( $post_type );
+				$post_type_obj = $post_type ? get_post_type_object( $post_type ) : null;
+				$archive_link  = $post_type ? get_post_type_archive_link( $post_type ) : false;
 
 				if ( $archive_link && $post_type_obj ) {
 					echo '<a href="' . esc_url( $archive_link ) . '">' . esc_html( $post_type_obj->labels->name ) . '</a>';
 				}
 			} elseif ( is_page() ) {
-				$parent_id = wp_get_post_parent_id( get_the_ID() );
-				if ( $parent_id ) {
-					$parent_title = get_the_title( $parent_id );
-					$parent_url   = get_permalink( $parent_id );
-					echo '<a href="' . esc_url( $parent_url ) . '">' . esc_html( $parent_title ) . '</a> › ';
+				$current_id = get_the_ID();
+				if ( false !== $current_id ) {
+					$parent_id = wp_get_post_parent_id( $current_id );
+					if ( $parent_id ) {
+						$parent_title = get_the_title( $parent_id );
+						$parent_url   = get_permalink( $parent_id );
+						echo '<a href="' . esc_url( (string) $parent_url ) . '">' . esc_html( $parent_title ) . '</a> › ';
+					}
 				}
 				echo '<span class="breadcrumb-title">' . esc_html( get_the_title() ) . '</span>';
 			}
 
-			if ( is_page() ) {
-				// Pages fully handled above, skip this chain
-			} elseif ( is_singular() && ! is_front_page() ) {
-				echo '<span class="breadcrumb-title"> › ' . esc_html( get_the_title() ) . '</span>';
-			} elseif ( is_post_type_archive() ) {
-				$post_type     = get_post_type();
-				$post_type_obj = get_post_type_object( $post_type );
+			// Trailing breadcrumb title. Pages are fully handled above and skip this chain.
+			if ( ! is_page() ) {
+				if ( is_singular() && ! is_front_page() ) {
+					echo '<span class="breadcrumb-title"> › ' . esc_html( get_the_title() ) . '</span>';
+				} elseif ( is_post_type_archive() ) {
+					$post_type     = get_post_type();
+					$post_type_obj = $post_type ? get_post_type_object( $post_type ) : null;
 
-				if ( $post_type_obj ) {
-					echo '<span>' . esc_html( $post_type_obj->labels->name ) . '</span>';
-				}
-			} elseif ( is_category() ) {
-				$category = get_queried_object();
-				if ( $category->parent ) {
-					$parent_category = get_category( $category->parent );
-					echo '<a href="' . esc_url( get_category_link( $parent_category->term_id ) ) . '">' . esc_html( $parent_category->name ) . '</a> › ';
-				}
-				echo '<span>' . esc_html( single_cat_title( '', false ) ) . '</span>';
-			} elseif ( is_tag() ) {
-				echo '<span>' . esc_html( single_tag_title( '', false ) ) . '</span>';
-			} elseif ( is_tax() ) {
-				$term     = get_queried_object();
-				$taxonomy = get_taxonomy( $term->taxonomy );
-
-				if ( $taxonomy ) {
-					if ( ! $taxonomy->hierarchical ) {
-						echo '<span>' . esc_html( $taxonomy->labels->name ) . '</span> › ';
+					if ( $post_type_obj ) {
+						echo '<span>' . esc_html( $post_type_obj->labels->name ) . '</span>';
 					}
-
-					if ( $taxonomy->hierarchical && $term->parent ) {
-						$parents = get_ancestors( $term->term_id, $term->taxonomy );
-						if ( ! empty( $parents ) ) {
-							$parents = array_reverse( $parents );
-							foreach ( $parents as $parent_id ) {
-								$parent_term = get_term( $parent_id, $term->taxonomy );
-								echo '<a href="' . esc_url( get_term_link( $parent_term ) ) . '">' . esc_html( $parent_term->name ) . '</a> › ';
-							}
+				} elseif ( is_category() ) {
+					$category = get_queried_object();
+					if ( $category instanceof WP_Term && $category->parent ) {
+						$parent_category = get_category( $category->parent );
+						if ( $parent_category instanceof WP_Term ) {
+							echo '<a href="' . esc_url( get_category_link( $parent_category->term_id ) ) . '">' . esc_html( $parent_category->name ) . '</a> › ';
 						}
 					}
+					echo '<span>' . esc_html( single_cat_title( '', false ) ) . '</span>';
+				} elseif ( is_tag() ) {
+					echo '<span>' . esc_html( single_tag_title( '', false ) ) . '</span>';
+				} elseif ( is_tax() ) {
+					$term = get_queried_object();
 
-					echo '<span>' . esc_html( $term->name ) . '</span>';
+					if ( $term instanceof WP_Term ) {
+						$taxonomy = get_taxonomy( $term->taxonomy );
+
+						if ( $taxonomy ) {
+							if ( ! $taxonomy->hierarchical ) {
+								echo '<span>' . esc_html( $taxonomy->labels->name ) . '</span> › ';
+							}
+
+							if ( $taxonomy->hierarchical && $term->parent ) {
+								$parents = get_ancestors( $term->term_id, $term->taxonomy );
+								if ( ! empty( $parents ) ) {
+									$parents = array_reverse( $parents );
+									foreach ( $parents as $parent_id ) {
+										$parent_term = get_term( $parent_id, $term->taxonomy );
+										if ( $parent_term instanceof WP_Term ) {
+											$parent_term_link = get_term_link( $parent_term );
+											if ( is_string( $parent_term_link ) ) {
+												echo '<a href="' . esc_url( $parent_term_link ) . '">' . esc_html( $parent_term->name ) . '</a> › ';
+											}
+										}
+									}
+								}
+							}
+
+							echo '<span>' . esc_html( $term->name ) . '</span>';
+						}
+					}
+				} elseif ( is_search() ) {
+					echo '<span>Search Results</span>';
+				} elseif ( is_author() ) {
+					$author = get_queried_object();
+					echo '<span>Author</span> › ';
+					if ( $author instanceof WP_User ) {
+						echo '<span>' . esc_html( $author->display_name ) . '</span>';
+					}
+				} elseif ( is_404() ) {
+					echo '<span>Page Not Found</span>';
+				} else {
+					echo '<span>Archives</span>';
 				}
-			} elseif ( is_search() ) {
-				echo '<span>Search Results</span>';
-			} elseif ( is_author() ) {
-				$author = get_queried_object();
-				echo '<span>Author</span> › ';
-				echo '<span>' . esc_html( $author->display_name ) . '</span>';
-			} elseif ( is_404() ) {
-				echo '<span>Page Not Found</span>';
-			} else {
-				echo '<span>Archives</span>';
 			}
 		}
 
-		// Allow plugins to append custom breadcrumb items
+		// Allow plugins to append custom breadcrumb items.
 		do_action( 'extrachill_breadcrumbs_append' );
 
-			echo '</nav>';
-		}
+		echo '</nav>';
 	}
+}

--- a/inc/core/templates/no-results.php
+++ b/inc/core/templates/no-results.php
@@ -17,7 +17,15 @@ if ( ! function_exists( 'extrachill_no_results' ) ) :
 			<div class="page-content">
 				<?php if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-					<p><?php printf( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'extrachill' ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
+					<p>
+					<?php
+					printf(
+						/* translators: %1$s: URL to the post creation screen. */
+						wp_kses_post( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'extrachill' ) ),
+						esc_url( admin_url( 'post-new.php' ) )
+					);
+					?>
+					</p>
 
 				<?php elseif ( is_search() ) : ?>
 

--- a/inc/core/templates/pagination.php
+++ b/inc/core/templates/pagination.php
@@ -51,7 +51,7 @@ function extrachill_pagination( $query_or_data = null, $context = 'default', $it
 		$total_items = $pagination_query->found_posts;
 		$per_page    = $pagination_query->query_vars['posts_per_page'];
 
-		if ( $per_page == -1 ) {
+		if ( -1 === $per_page ) {
 			$per_page = $total_items;
 		}
 	}
@@ -61,16 +61,16 @@ function extrachill_pagination( $query_or_data = null, $context = 'default', $it
 
 	// Build count text with dynamic item label
 	$item_plural = $item_label . 's';
-	if ( 1 == $total_items ) {
+	if ( 1 === $total_items ) {
 		$count_html = sprintf( 'Viewing 1 %s', $item_label );
-	} elseif ( $end == $start ) {
+	} elseif ( $end === $start ) {
 		$count_html = sprintf( 'Viewing %s %s of %s', $item_label, number_format( $start ), number_format( $total_items ) );
 	} else {
 		$count_html = sprintf( 'Viewing %s %s-%s of %s total', $item_plural, number_format( $start ), number_format( $end ), number_format( $total_items ) );
 	}
 
 	$big      = 999999999;
-	$base_url = str_replace( $big, '%#%', esc_url( get_pagenum_link( $big ) ) );
+	$base_url = str_replace( (string) $big, '%#%', esc_url( get_pagenum_link( $big ) ) );
 
 	$links_html = paginate_links(
 		array(
@@ -96,7 +96,7 @@ function extrachill_pagination( $query_or_data = null, $context = 'default', $it
 	if ( $links_html ) {
 		echo '<div class="extrachill-pagination pagination-' . esc_attr( $context ) . '">';
 		echo '<div class="pagination-count">' . esc_html( $count_html ) . '</div>';
-		echo '<div class="pagination-links">' . $links_html . '</div>';
+		echo '<div class="pagination-links">' . wp_kses_post( $links_html ) . '</div>';
 		echo '</div>';
 	}
 }

--- a/inc/core/templates/post-meta.php
+++ b/inc/core/templates/post-meta.php
@@ -36,7 +36,7 @@ if ( ! function_exists( 'extrachill_entry_meta' ) ) :
 			$author_id  = isset( $post->post_author ) ? $post->post_author : 0;
 			$author_url = function_exists( 'extrachill_get_user_profile_url' )
 				? extrachill_get_user_profile_url( $author_id )
-				: ec_get_site_url( 'community' ) . '/u/' . sanitize_title( $author );
+				: ( function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) . '/u/' . sanitize_title( $author ) : home_url( '/' ) . 'u/' . sanitize_title( $author ) );
 
 			$forum_title = isset( $post->_forum['title'] ) ? esc_html( $post->_forum['title'] ) : 'Unknown Forum';
 			$forum_link  = isset( $post->_forum['link'] ) ? esc_url( $post->_forum['link'] ) : '#';
@@ -54,7 +54,7 @@ if ( ! function_exists( 'extrachill_entry_meta' ) ) :
 				echo '</div>';
 		} else {
 			$post_id   = get_the_ID();
-			$post_type = get_post_type( $post_id );
+			$post_type = false !== $post_id ? get_post_type( $post_id ) : '';
 
 			$parts = apply_filters( 'extrachill_post_meta_parts', array( 'published', 'author', 'updated' ), $post_id, $post_type );
 
@@ -62,13 +62,13 @@ if ( ! function_exists( 'extrachill_entry_meta' ) ) :
 			$show_author    = in_array( 'author', $parts, true );
 			$show_updated   = in_array( 'updated', $parts, true );
 
-			$published_time    = esc_attr( get_the_date( 'c' ) );
-			$modified_time     = esc_attr( get_the_modified_date( 'c' ) );
-			$published_display = esc_html( get_the_date() );
-			$modified_display  = esc_html( get_the_modified_date() );
+			$published_time    = esc_attr( (string) get_the_date( 'c' ) );
+			$modified_time     = esc_attr( (string) get_the_modified_date( 'c' ) );
+			$published_display = esc_html( (string) get_the_date() );
+			$modified_display  = esc_html( (string) get_the_modified_date() );
 
-			$published_datetime = new DateTime( get_the_date( 'Y-m-d' ) );
-			$modified_datetime  = new DateTime( get_the_modified_date( 'Y-m-d' ) );
+			$published_datetime = new DateTime( (string) get_the_date( 'Y-m-d' ) );
+			$modified_datetime  = new DateTime( (string) get_the_modified_date( 'Y-m-d' ) );
 			$date_diff          = $published_datetime->diff( $modified_datetime );
 			$is_updated         = get_the_time( 'U' ) !== get_the_modified_time( 'U' ) && $date_diff->days >= 1;
 

--- a/inc/core/templates/searchform.php
+++ b/inc/core/templates/searchform.php
@@ -22,7 +22,7 @@ if ( ! function_exists( 'extrachill_search_form' ) ) {
 		<form action="<?php echo esc_url( home_url( '/' ) ); ?>" class="search-form searchform" method="get">
 			<div class="search-wrap">
 				<input type="search" placeholder="<?php esc_attr_e( 'Enter search terms...', 'extrachill' ); ?>" class="s field" name="s" value="<?php echo esc_attr( get_search_query() ); ?>">
-				<button class="button-1 button-medium" type="submit" aria-label="<?php esc_attr_e( 'Search', 'extrachill' ); ?>"><?php echo ec_icon( 'search', 'search-top' ); ?></button>
+				<button class="button-1 button-medium" type="submit" aria-label="<?php esc_attr_e( 'Search', 'extrachill' ); ?>"><?php echo ec_icon( 'search', 'search-top' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_icon() returns SVG markup built from a fixed template with esc_attr()'d values. ?></button>
 			</div>
 			<fieldset class="search-scope" role="radiogroup" aria-label="<?php esc_attr_e( 'Search scope', 'extrachill' ); ?>">
 				<legend class="screen-reader-text"><?php esc_html_e( 'Choose where to search', 'extrachill' ); ?></legend>

--- a/inc/core/templates/share.php
+++ b/inc/core/templates/share.php
@@ -19,25 +19,25 @@ if ( ! function_exists( 'extrachill_share_button' ) ) :
 	function extrachill_share_button( $args = array() ) {
 		wp_enqueue_script( 'extrachill-share' );
 
-		if ( isset( $args ) && is_array( $args ) ) {
-			extract( $args );
-		}
+		$share_url   = isset( $args['share_url'] ) ? $args['share_url'] : '';
+		$share_title = isset( $args['share_title'] ) ? $args['share_title'] : '';
+		$button_size = isset( $args['button_size'] ) ? $args['button_size'] : 'button-small';
 
-		if ( isset( $share_url ) && is_array( $share_url ) ) {
+		if ( is_array( $share_url ) ) {
 			$share_url = reset( $share_url );
 		}
 
-		if ( isset( $share_title ) && is_array( $share_title ) ) {
+		if ( is_array( $share_title ) ) {
 			$share_title = reset( $share_title );
 		}
 
-		$share_url   = isset( $share_url ) ? esc_url( $share_url ) : get_permalink();
-		$share_title = isset( $share_title ) ? esc_attr( $share_title ) : get_the_title();
-		$button_size = isset( $button_size ) ? esc_attr( $button_size ) : 'button-small';
+		$share_url   = $share_url ? esc_url( $share_url ) : (string) get_permalink();
+		$share_title = $share_title ? esc_attr( $share_title ) : get_the_title();
+		$button_size = esc_attr( $button_size );
 		?>
-		<div class="ec-mini-dropdown share-dropdown" aria-expanded="false" data-post-id="<?php echo esc_attr( get_the_ID() ); ?>" data-blog-id="<?php echo esc_attr( get_current_blog_id() ); ?>">
+		<div class="ec-mini-dropdown share-dropdown" aria-expanded="false" data-post-id="<?php echo esc_attr( (string) get_the_ID() ); ?>" data-blog-id="<?php echo esc_attr( (string) get_current_blog_id() ); ?>">
 			<button class="ec-mini-dropdown-toggle button-2 <?php echo esc_attr( $button_size ); ?>">
-				<?php echo ec_icon( 'share' ); ?> Share
+				<?php echo ec_icon( 'share' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_icon() returns SVG markup built from a fixed template with esc_attr()'d values. ?> Share
 			</button>
 			<ul class="ec-mini-dropdown-menu" role="menu">
 				<li role="menuitem" class="share-option facebook">

--- a/inc/core/templates/social-links.php
+++ b/inc/core/templates/social-links.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'extrachill_social_links' ) ) :
 				<?php foreach ( $social_links as $social ) : ?>
 					<li>
 						<a href="<?php echo esc_url( $social['url'] ); ?>" target="_blank" aria-label="<?php echo esc_attr( $social['label'] ); ?>">
-							<?php echo ec_icon( $social['icon'], 'social-icon-svg' ); ?>
+							<?php echo ec_icon( $social['icon'], 'social-icon-svg' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_icon() returns SVG markup built from a fixed template with esc_attr()'d values. ?>
 						</a>
 					</li>
 				<?php endforeach; ?>

--- a/inc/core/templates/taxonomy-badges.php
+++ b/inc/core/templates/taxonomy-badges.php
@@ -16,7 +16,7 @@
  * Maintains CSS compatibility with existing badge-colors.css styles.
  *
  * @param int|null $post_id Post ID. Defaults to current post.
- * @param array $args Configuration arguments.
+ * @param array    $args Configuration arguments.
  */
 function extrachill_display_taxonomy_badges( $post_id = null, $args = array() ) {
 	if ( ! $post_id ) {
@@ -50,7 +50,7 @@ function extrachill_display_taxonomy_badges( $post_id = null, $args = array() ) 
 
 	// Get ALL taxonomies for this post type (from origin site if cross-site)
 	$post_type  = get_post_type( $post_id );
-	$taxonomies = get_object_taxonomies( $post_type );
+	$taxonomies = $post_type ? get_object_taxonomies( $post_type ) : array();
 
 	// Define display order for taxonomy badges
 	$taxonomy_order = array(
@@ -81,6 +81,7 @@ function extrachill_display_taxonomy_badges( $post_id = null, $args = array() ) 
 	);
 
 	// Process each taxonomy dynamically
+	$cross_site_links = array();
 	foreach ( $taxonomies as $taxonomy ) {
 		if ( in_array( $taxonomy, $excluded_taxonomies, true ) ) {
 			continue;
@@ -104,7 +105,7 @@ function extrachill_display_taxonomy_badges( $post_id = null, $args = array() ) 
 						$rewrite_slug = $tax_obj && isset( $tax_obj->rewrite['slug'] ) ? $tax_obj->rewrite['slug'] : $taxonomy;
 
 						// Manually construct archive URL: https://site.com/taxonomy-slug/term-slug/
-						$term->cross_site_link = trailingslashit( $origin_site_url ) . trailingslashit( $rewrite_slug ) . $term_slug . '/';
+						$cross_site_links[ $term->term_id ] = trailingslashit( $origin_site_url ) . trailingslashit( $rewrite_slug ) . $term_slug . '/';
 					}
 
 					$terms[] = $term;
@@ -155,7 +156,10 @@ function extrachill_display_taxonomy_badges( $post_id = null, $args = array() ) 
 			}
 
 			// Use manually constructed cross-site link if available, otherwise use get_term_link()
-			$term_link = isset( $term->cross_site_link ) ? $term->cross_site_link : get_term_link( $term );
+			$term_link = isset( $cross_site_links[ $term->term_id ] ) ? $cross_site_links[ $term->term_id ] : get_term_link( $term );
+			if ( ! is_string( $term_link ) ) {
+				continue;
+			}
 
 			$badge_label = $term->name;
 
@@ -176,12 +180,15 @@ function extrachill_display_taxonomy_badges( $post_id = null, $args = array() ) 
 	// Output badges
 	if ( $badges_html ) {
 		if ( $args['show_wrapper'] ) {
-			$wrapper_style = $args['wrapper_style'] ? ' style="' . esc_attr( $args['wrapper_style'] ) . '"' : '';
-			echo '<div class="' . esc_attr( $args['wrapper_class'] ) . '"' . $wrapper_style . '>';
-			echo $badges_html;
+			echo '<div class="' . esc_attr( $args['wrapper_class'] ) . '"';
+			if ( $args['wrapper_style'] ) {
+				echo ' style="' . esc_attr( $args['wrapper_style'] ) . '"';
+			}
+			echo '>';
+			echo wp_kses_post( $badges_html );
 			echo '</div>';
 		} else {
-			echo $badges_html;
+			echo wp_kses_post( $badges_html );
 		}
 	}
 }

--- a/inc/header/header-search.php
+++ b/inc/header/header-search.php
@@ -14,14 +14,14 @@ add_action(
 		?>
 	<button type="button" class="search-icon header-right-icon" aria-haspopup="dialog" aria-expanded="false" aria-controls="header-search-panel">
 		<span class="screen-reader-text"><?php esc_html_e( 'Open site search', 'extrachill' ); ?></span>
-		<?php echo ec_icon( 'search', 'search-top' ); ?>
+		<?php echo ec_icon( 'search', 'search-top' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_icon() returns SVG markup built from a fixed template with esc_attr()'d values. ?>
 	</button>
 
 	<div id="header-search-panel" class="header-search-panel" role="dialog" aria-modal="true" aria-label="<?php esc_attr_e( 'Site Search', 'extrachill' ); ?>">
 		<div class="header-search-panel__inner">
 			<button type="button" class="search-close-button">
 				<span class="screen-reader-text"><?php esc_html_e( 'Close site search', 'extrachill' ); ?></span>
-				<?php echo ec_icon( 'close', 'search-close-icon' ); ?>
+				<?php echo ec_icon( 'close', 'search-close-icon' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_icon() returns SVG markup built from a fixed template with esc_attr()'d values. ?>
 			</button>
 			<?php extrachill_search_form(); ?>
 		</div>

--- a/inc/sidebar/recent-posts.php
+++ b/inc/sidebar/recent-posts.php
@@ -21,12 +21,12 @@ if ( ! function_exists( 'extrachill_sidebar_recent_posts' ) ) :
 	function extrachill_sidebar_recent_posts() {
 		$custom_content = apply_filters( 'extrachill_sidebar_recent_posts_content', false );
 		if ( false !== $custom_content ) {
-			echo $custom_content;
+			echo wp_kses_post( $custom_content );
 			return;
 		}
 
 		$post_id           = get_the_ID();
-		$current_post_type = get_post_type( $post_id );
+		$current_post_type = false !== $post_id ? get_post_type( $post_id ) : '';
 		$args              = array();
 		$title             = 'Recent Posts';
 
@@ -83,7 +83,7 @@ if ( ! function_exists( 'extrachill_sidebar_recent_posts' ) ) :
 			echo '<div class="sidebar-card ec-surface-card ec-mobile-full-width-panel">';
 			echo '<div class="widget my-recent-posts-widget">';
 			echo '<div class="my-recent-posts">';
-			echo '<h3 class="widget-title sidebar-recent-title-margin"><span>' . $title . '</span></h3>';
+			echo '<h3 class="widget-title sidebar-recent-title-margin"><span>' . wp_kses_post( $title ) . '</span></h3>';
 
 			$counter = 0;
 			while ( $query->have_posts() ) :
@@ -91,9 +91,9 @@ if ( ! function_exists( 'extrachill_sidebar_recent_posts' ) ) :
 				++$counter;
 				echo '<div class="post mini-card">';
 				if ( has_post_thumbnail() ) {
-					echo '<a id="post-thumbnail-link-' . $counter . '" href="' . get_permalink() . '" aria-label="Read more about ' . esc_attr( get_the_title() ) . ', an image is attached"><div class="post-thumbnail">' . get_the_post_thumbnail( get_the_ID(), 'medium_large' ) . '</div></a>';
+					echo '<a id="post-thumbnail-link-' . esc_attr( (string) $counter ) . '" href="' . esc_url( (string) get_permalink() ) . '" aria-label="Read more about ' . esc_attr( get_the_title() ) . ', an image is attached"><div class="post-thumbnail">' . wp_kses_post( get_the_post_thumbnail( null, 'medium_large' ) ) . '</div></a>';
 				}
-				echo '<h2 class="recent-title"><a id="post-title-link-' . $counter . '" href="' . get_permalink() . '" aria-label="Read more about ' . esc_attr( get_the_title() ) . '">' . get_the_title() . '</a></h2>';
+				echo '<h2 class="recent-title"><a id="post-title-link-' . esc_attr( (string) $counter ) . '" href="' . esc_url( (string) get_permalink() ) . '" aria-label="Read more about ' . esc_attr( get_the_title() ) . '">' . esc_html( get_the_title() ) . '</a></h2>';
 				echo '</div>';
 			endwhile;
 

--- a/inc/single/comments.php
+++ b/inc/single/comments.php
@@ -19,7 +19,6 @@ if ( post_password_required() ) {
 if ( ! function_exists( 'extrachill_comment' ) ) :
 
 	function extrachill_comment( $comment, $args, $depth ) {
-		$GLOBALS['comment'] = $comment;
 		switch ( $comment->comment_type ) :
 			case 'trackback':
 				?>
@@ -35,24 +34,24 @@ if ( ! function_exists( 'extrachill_comment' ) ) :
 						<?php
 						echo get_avatar( $comment, 74 );
 
-						if ( ec_should_use_multisite_comment_links( $comment ) ) {
-							$author_link = ec_get_comment_author_link_multisite( $comment );
+						if ( function_exists( 'ec_should_use_multisite_comment_links' ) && ec_should_use_multisite_comment_links( $comment ) ) {
+							$author_link = function_exists( 'ec_get_comment_author_link_multisite' ) ? ec_get_comment_author_link_multisite( $comment ) : get_comment_author_link();
 						} else {
 							$author_link = get_comment_author_link();
 						}
 
-						printf( '<div class="comment-author-link">%s</div>', $author_link );
+						printf( '<div class="comment-author-link">%s</div>', wp_kses_post( $author_link ) );
 
 						if ( $comment->user_id === $post->post_author ) {
-							echo '<span>' . __( 'Post author', 'extrachill' ) . '</span>';
+							echo '<span>' . esc_html__( 'Post author', 'extrachill' ) . '</span>';
 						}
 
-						printf( '<div class="comment-date-time">%1$s</div>', sprintf( __( '%1$s at %2$s', 'extrachill' ), get_comment_date(), get_comment_time() ) );
+						printf( '<div class="comment-date-time">%1$s</div>', sprintf( /* translators: 1: comment date, 2: comment time. */ esc_html__( '%1$s at %2$s', 'extrachill' ), esc_html( get_comment_date() ), esc_html( get_comment_time() ) ) );
 						edit_comment_link();
 						?>
 					</header>
 
-					<?php if ( '0' == $comment->comment_approved ) : ?>
+					<?php if ( '0' === $comment->comment_approved ) : ?>
 						<p class="comment-awaiting-moderation"><?php esc_html_e( 'Your comment is awaiting moderation.', 'extrachill' ); ?></p>
 					<?php endif; ?>
 
@@ -87,10 +86,13 @@ endif;
 	<?php if ( have_comments() ) : ?>
 		<h2 class="comments-title">
 			<?php
+				$comments_number = (int) get_comments_number();
+				/* translators: 1: number of comments, 2: post title. */
+				$comments_title = _nx( 'One comment on &ldquo;%2$s&rdquo;', '%1$s comments on <strong>%2$s</strong>', $comments_number, 'comments title', 'extrachill' ); // phpcs:ignore WordPress.WP.I18n.MissingSingularPlaceholder -- Singular form intentionally spells out "One" rather than using a numeric placeholder.
 				printf(
-					_nx( 'One comment on &ldquo;%2$s&rdquo;', '%1$s comments on <strong>%2$s</strong>', get_comments_number(), 'comments title', 'extrachill' ),
-					number_format_i18n( get_comments_number() ),
-					'<span>' . get_the_title() . '</span>'
+					wp_kses_post( $comments_title ),
+					esc_html( number_format_i18n( $comments_number ) ),
+					'<span>' . esc_html( get_the_title() ) . '</span>'
 				);
 			?>
 		</h2>
@@ -125,7 +127,7 @@ endif;
 	<?php endif; ?>
 
 	<?php
-	if ( ! comments_open() && '0' != get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
+	if ( ! comments_open() && (int) get_comments_number() !== 0 && post_type_supports( (string) get_post_type(), 'comments' ) ) :
 		?>
 		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'extrachill' ); ?></p>
 	<?php endif; ?>

--- a/inc/single/related-posts.php
+++ b/inc/single/related-posts.php
@@ -36,7 +36,10 @@ function extrachill_display_related_posts( $taxonomy, $post_id ) {
 		$term      = $terms[0];
 		$term_id   = $term->term_id;
 		$term_link = get_term_link( $term );
-		$term_name = esc_html( $term->name );
+	if ( is_wp_error( $term_link ) ) {
+		$term_link = '';
+	}
+		$term_name = $term->name;
 
 	$cache_key          = $taxonomy . '_posts_' . $term_id . '_' . $post_id;
 	$related_posts_data = get_transient( $cache_key );
@@ -79,7 +82,7 @@ function extrachill_display_related_posts( $taxonomy, $post_id ) {
 					'lazy_load_term_meta'    => false,
 					'ignore_sticky_posts'    => false,
 				),
-				$related_posts->query_vars ?? array()
+				$related_posts->query_vars
 			);
 
 			$related_posts->current_post = -1;
@@ -89,6 +92,9 @@ function extrachill_display_related_posts( $taxonomy, $post_id ) {
 		$filtered_posts = array_filter(
 			$related_posts->posts,
 			function ( $post ) use ( &$displayed_posts ) {
+				if ( ! $post instanceof WP_Post ) {
+					return false;
+				}
 				if ( in_array( $post->ID, $displayed_posts, true ) ) {
 					return false;
 				}
@@ -103,7 +109,7 @@ function extrachill_display_related_posts( $taxonomy, $post_id ) {
 
 	if ( $related_posts->have_posts() ) : ?>
 				<div class="related-tax-section">
-						<h3 class="related-tax-header">More from <a href="<?php echo esc_url( $term_link ); ?>"><?php echo $term_name; ?></a></h3>
+						<h3 class="related-tax-header">More from <a href="<?php echo esc_url( $term_link ); ?>"><?php echo esc_html( $term_name ); ?></a></h3>
 						<div class="related-tax-grid">
 								<?php
 								while ( $related_posts->have_posts() ) :

--- a/inc/single/single-post.php
+++ b/inc/single/single-post.php
@@ -34,7 +34,7 @@ get_header(); ?>
 		<figure class="wp-block-image size-large">
 			<?php the_post_thumbnail( 'large' ); ?>
 			<?php
-			$featured_image_caption = wp_get_attachment_caption( $featured_image_id );
+			$featured_image_caption = wp_get_attachment_caption( (int) $featured_image_id );
 			if ( ! empty( $featured_image_caption ) ) {
 				echo '<figcaption class="wp-element-caption">' . wp_kses_post( $featured_image_caption ) . '</figcaption>';
 			}
@@ -54,17 +54,19 @@ get_header(); ?>
 	<aside>
 		<?php
 		do_action( 'extrachill_before_comments_template' );
-		if ( comments_open() || '0' != get_comments_number() ) {
+		if ( comments_open() || (int) get_comments_number() !== 0 ) {
 			do_action( 'extrachill_comments_section' );
 		}
 		do_action( 'extrachill_after_comments_template' );
 		require_once get_template_directory() . '/inc/single/related-posts.php';
 
-		$post_id            = get_the_ID();
-		$related_taxonomies = apply_filters( 'extrachill_related_posts_taxonomies', array( 'artist', 'venue' ), $post_id, get_post_type() );
+		$current_post_id    = get_the_ID();
+		$related_taxonomies = apply_filters( 'extrachill_related_posts_taxonomies', array( 'artist', 'venue' ), $current_post_id, get_post_type() );
 
-		foreach ( $related_taxonomies as $taxonomy ) {
-			extrachill_display_related_posts( $taxonomy, $post_id );
+		foreach ( $related_taxonomies as $related_taxonomy ) {
+			if ( false !== $current_post_id ) {
+				extrachill_display_related_posts( $related_taxonomy, $current_post_id );
+			}
 		}
 		?>
 	</aside>

--- a/scripts/build-taxonomy-badges.js
+++ b/scripts/build-taxonomy-badges.js
@@ -6,6 +6,9 @@
  * from @extrachill/tokens.
  */
 
+/**
+ * External dependencies
+ */
 const fs = require('fs');
 const path = require('path');
 
@@ -51,4 +54,5 @@ const output = baseStyles + '\n' + tokensCSS;
 const outPath = path.join(__dirname, '..', 'assets', 'css', 'taxonomy-badges.css');
 
 fs.writeFileSync(outPath, output);
+// eslint-disable-next-line no-console -- build-time progress output.
 console.log(`Built ${outPath} (${output.split('\n').length} lines)`);

--- a/sidebar.php
+++ b/sidebar.php
@@ -15,7 +15,7 @@
 	$sidebar_content = apply_filters( 'extrachill_sidebar_content', false );
 
 	if ( false !== $sidebar_content ) {
-		echo $sidebar_content;
+		echo wp_kses_post( $sidebar_content );
 	} else {
 		do_action( 'extrachill_before_sidebar' );
 		do_action( 'extrachill_sidebar_top' );


### PR DESCRIPTION
## Summary

Clears all pre-existing lint findings across the theme so `homeboy lint extrachill` passes on the whole tree, removing the need for `--skip-checks` on `homeboy release extrachill`.

**Style, type, and escaping fixes only — no logic or feature changes.**

## Per-tool before / after

| Tool   | Before (errors / warnings) | After |
|--------|----------------------------|-------|
| phpcs  | 66 errors / 14 warnings    | 0 / 0 |
| eslint | 34 errors / 2 warnings     | 0 / 0 |
| phpstan (level 7) | 82 errors       | 0     |
| **Total** | **198 findings**        | **0** |

Verified with `homeboy lint extrachill` (whole tree) reporting **zero errors and zero warnings** across all three tools.

## Categories of fixes

**phpcs (escaping + conventions):**
- Added escaping (`wp_kses_post`/`esc_url`/`esc_html`/`esc_attr`) to previously-unescaped output in `breadcrumbs.php`, `sidebar.php`, `inc/single/comments.php`, `inc/archives/archive-header.php`, `inc/archives/post-card.php`, `inc/core/templates/share.php`, `taxonomy-badges.php`, `pagination.php`, `recent-posts.php`, `filter-bar.php`, `no-results.php`.
- Replaced `extract()` in `share.php` with explicit array access.
- `gmdate()` instead of `date()` in `footer.php`.
- Yoda + strict comparisons (`pagination.php`, `archive-custom-sorting.php`, `comments.php`).
- Removed the redundant `$GLOBALS['comment'] = $comment` in the comment callback (modern WP provides the loop comment).
- Renamed locals that shadowed WP globals (`$domain`, `$post_id`, `$taxonomy`, `$tax`, `$class`, `$match`).
- Guarded `int|false` before taxonomy-badge calls (no short ternary).
- Narrowly-scoped `phpcs:ignore` with rationale for the few cases that genuinely cannot be cleanly escaped: `ec_icon()` SVG output (fixed template + `esc_attr`), Instagram oEmbed provider `<script>`, the CSS-var `<style>` block, and GET-based sort reads.

**phpstan (level 7):**
- Cast `filemtime()` / `get_the_date()` / `wp_json_encode()` to `string` where WP stubs widen the return type.
- `instanceof`/`is_string` guards for `get_queried_object()`, `get_term_link()`, `get_category()`, and `get_permalink()` union/nullable returns.
- Guarded `COOKIEPATH` via `defined()` and added `function_exists` guards for plugin-provided functions (`ec_get_site_url`, `ec_should_use_multisite_comment_links`, `ec_get_comment_author_link_multisite`).
- Typed the `preg_replace_callback` closure (`array $matches`) + `(string)` return in `functions.php`.
- Fixed a latent out-of-scope `allPanes` reference in `shared-tabs.js`'s resize handler (declared it locally — matching the identical pattern already used in `updateTabs`).

**eslint:**
- `var` → `let`/`const`, added braces to single-line `if`s, `prefer-const`.
- Added the `External dependencies` comment block to `build-taxonomy-badges.js` (`@wordpress/dependency-group`).
- Dropped invalid `@package` tags from JS docblocks (`jsdoc/empty-tags`).
- Declared the browser `history` global in `shared-tabs.js` (`/* global history */`).
- Scoped `eslint-disable-next-line no-console` for the build-time/activation `console.log` calls, matching the existing pattern in `scripts/build-design-system.js`.

## Untouched
- `design-system.html` and `scripts/build-design-system.js` were **not modified** — they already lint clean.

## Behavior
Behavior is unchanged. Where escaping was added, the values were already trusted/controlled (filtered HTML escaped with `wp_kses_post`, URLs with `esc_url`, etc.). The only runtime-visible change is the `allPanes` reference in `shared-tabs.js`, which previously threw a `ReferenceError` on the no-active-button resize path; it now does what the surrounding code intended. `php -l` and `node --check` pass on every touched file, and the `build-taxonomy-badges.js` build runs successfully.

## Do not
- This PR is for review only — not merging from here.