### PR TITLE
feat(design-system): full-width .button-block button modifier for mobile action rows

### DIFF
--- a/style.css
+++ b/style.css
@@ -1584,6 +1584,30 @@ button.button-large {
   font-size: var(--font-size-body);
 }
 
+/*
+ * Full-width / block modifier.
+ *
+ * Composable SIZE modifier — pair it with any color variant
+ * (.button-1 / .button-2 / .button-3 / .button-danger) and any size
+ * variant (.button-small / .button-medium / .button-large). It only
+ * controls width, so it stacks cleanly with the existing axes, e.g.:
+ *   <a class="button-1 button-medium button-block">Save to Calendar</a>
+ *
+ * Always-on opt-in block: consumers apply it where edge-to-edge buttons
+ * are wanted (e.g. mobile action rows). Using text-align:center keeps the
+ * label centered even though display:block stretches the box. box-sizing
+ * ensures padding doesn't overflow the container.
+ */
+.button-block,
+a.button-block,
+input.button-block,
+button.button-block {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+}
+
 
 
 /* SVG Icon System */


### PR DESCRIPTION
## Summary

Adds a composable **full-width / block** size modifier (`.button-block`) to the shared theme button system in `style.css`, so action-button rows can render edge-to-edge. The driving case is the single-event-page action row (Save to Calendar / Buy Tickets / Going) being easier to tap and less cluttered on mobile, but the variant is platform-wide by design.

Closes #59

## What it does

```css
.button-block,
a.button-block,
input.button-block,
button.button-block {
  display: block;
  width: 100%;
  box-sizing: border-box;
  text-align: center;
}
```

Usage — stack it with the existing axes:

```html
<a class="button-1 button-medium button-block">Save to Calendar</a>
```

## Variant shape & design-system reasoning

- **Modifier, not a new button.** It only controls width, so it composes cleanly with the existing **color** axis (`.button-1` / `.button-2` / `.button-3` / `.button-danger`) and **size** axis (`.button-small` / `.button-medium` / `.button-large`). No duplication of color/padding rules.
- **Always-on opt-in block, not a mobile `@media` scope.** Per the issue's preference: an always-block variant that consumers apply *where they want it* is simpler and more predictable than baking a breakpoint into the shared system. Consumers that only want it on mobile can scope their own application of the class; the shared primitive stays unopinionated about breakpoints.
- `box-sizing: border-box` keeps the existing padding from overflowing the container; `text-align: center` keeps the label centered now that the box stretches.

## Tokens: not needed

No `@extrachill/tokens` change was required. `width: 100%` is not a shareable value, and existing spacing tokens (`--spacing-*`) already cover action-row gap and button padding. Per the design-system rule, generated `root.css` was **not** hand-edited. (The build still copies `root.css`/`theme.json` from the tokens package and regenerates `design-system.html`/`taxonomy-badges.css` cleanly — those outputs are not tracked in this repo, so the only committed change is `style.css`.)

## Scope / adoption follow-ups

This PR ships **only** the reusable variant. It does not convert any surface. Suggested follow-up adopters (separate changes, via each surface's own button-class filters/markup — no theme coupling):

- **Events action row** (extrachill-events / data-machine-events) — opt the event-page action row into `button-block` via the existing `data_machine_events_add_to_calendar_button_classes` / ticket-button class filters. This is the originally requested surface.
- **Artist platform link pages** — full-width link buttons are the native pattern there.
- **Forms** (contact / newsletter / submit) — full-width submit buttons on mobile.

## Verification

- `npm run build` runs clean (copies tokens `root.css`/`theme.json`, regenerates badges + design-system page).
- Only `style.css` is modified; no generated `root.css` edits, no version/changelog edits.