### PR TITLE
build: track package.json in homeboy version_targets

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -10,6 +10,10 @@
     {
       "file": "style.css",
       "pattern": "(?m)^\\s*Version:\\s*([0-9.]+)"
+    },
+    {
+      "file": "package.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "extrachill-theme",
   "private": true,
-  "version": "2.0.12",
+  "version": "2.10.0",
   "description": "Extra Chill WordPress theme",
   "scripts": {
     "build": "cp node_modules/@extrachill/tokens/css/root.css assets/css/root.css && cp node_modules/@extrachill/tokens/css/theme.json theme.json && node scripts/build-taxonomy-badges.js && node scripts/build-design-system.js"


### PR DESCRIPTION
## Why

`package.json` `version` was stuck at **2.0.12** while the theme released all the way up to **2.10.0**. Cause: `homeboy.json` only listed `style.css` as a version_target, so `package.json` never got bumped on release and silently drifted.

It's harmless (the theme's package.json isn't published/consumed by version), but it's misleading — two version numbers that should match didn't.

## Changes

- **Add `package.json` as a second `version_targets` entry** in `homeboy.json`, with pattern `"version":\s*"([0-9.]+)"`, so homeboy bumps it in lockstep with `style.css` on every release going forward.
- **One-time sync** `package.json` `version` 2.0.12 → 2.10.0 to clear the existing drift. (Homeboy can only bump forward from the current value; without this reconciliation the next release would go 2.0.12 → 2.0.13 and perpetuate the mismatch. This is a one-time alignment, not a manual release bump.)

## Verification

```
homeboy version show extrachill
→ targets: style.css (match_count 1) + package.json (match_count 1)
→ version: 2.10.0   (both consistent)
```

Both JSON files validated; the package.json regex confirmed to capture `2.10.0`.

No CHANGELOG edits; the package.json change here is a one-time drift reconciliation, and from now on homeboy owns the bump for both files.