### PR TITLE
fix: make responsive card grids overflow-safe (min(100%, floor))

### DIFF
--- a/assets/css/archive.css
+++ b/assets/css/archive.css
@@ -160,7 +160,7 @@ a.card-link-target:hover,
 /* Grid layout for full-width archives and search results */
 .ec-mobile-full-width-panel .article-container {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(325px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 325px), 1fr));
     gap: var(--spacing-lg);
     width: 100%;
     max-width: var(--container-wide);
@@ -183,7 +183,7 @@ a.card-link-target:hover,
 /* Responsive adjustments */
 @media (max-width: 768px) {
 	.ec-mobile-full-width-panel .article-container {
-        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
         gap: var(--spacing-lg);
     }
 }

--- a/design-system.html
+++ b/design-system.html
@@ -84,7 +84,7 @@
 
   .swatch-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 220px), 1fr));
     gap: var(--spacing-md);
   }
   .swatch {
@@ -126,7 +126,7 @@
   .group__blurb { color: var(--muted-text); font-size: var(--font-size-sm); margin: 0 0 var(--spacing-md); }
 
   /* In-context examples — built entirely from live tokens. */
-  .examples { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: var(--spacing-lg); }
+  .examples { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr)); gap: var(--spacing-lg); }
   .example {
     background: var(--card-background);
     border: 1px solid var(--border-color);
@@ -174,7 +174,7 @@
   }
   .card p { margin: var(--spacing-xs) 0 var(--spacing-md); font-size: var(--font-size-sm); }
 
-  .fonts { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--spacing-md); }
+  .fonts { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr)); gap: var(--spacing-md); }
   .font {
     background: var(--card-background);
     border: 1px solid var(--border-color);

--- a/scripts/build-design-system.js
+++ b/scripts/build-design-system.js
@@ -275,7 +275,7 @@ const html = `<!DOCTYPE html>
 
   .swatch-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(100%, 220px), 1fr));
     gap: var(--spacing-md);
   }
   .swatch {
@@ -317,7 +317,7 @@ const html = `<!DOCTYPE html>
   .group__blurb { color: var(--muted-text); font-size: var(--font-size-sm); margin: 0 0 var(--spacing-md); }
 
   /* In-context examples — built entirely from live tokens. */
-  .examples { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: var(--spacing-lg); }
+  .examples { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr)); gap: var(--spacing-lg); }
   .example {
     background: var(--card-background);
     border: 1px solid var(--border-color);
@@ -365,7 +365,7 @@ const html = `<!DOCTYPE html>
   }
   .card p { margin: var(--spacing-xs) 0 var(--spacing-md); font-size: var(--font-size-sm); }
 
-  .fonts { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--spacing-md); }
+  .fonts { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr)); gap: var(--spacing-md); }
   .font {
     background: var(--card-background);
     border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
Adopts the overflow-safe `min(100%, <floor>)` card-grid pattern from Extra-Chill/extrachill-components#16 **locally**, without adding any dependency on the shared `@extrachill/components` stylesheet (the theme does not load it).

For each grid: `minmax(<floor>, 1fr)` → `minmax(min(100%, <floor>), 1fr)`. This prevents horizontal overflow when the viewport is narrower than the grid floor; layout is identical otherwise. `auto-fill`, gap, floor values, and all media-query overrides are preserved.

## Grids fixed
- `assets/css/archive.css` — `.article-container` grid (325px floor, auto-fill) and its `max-width: 768px` override (280px floor).
- `scripts/build-design-system.js` (source) — `.swatch-grid` (220px), `.examples` (300px), `.fonts` (280px).
- `design-system.html` — regenerated build artifact from the source above via `node scripts/build-design-system.js` (matches source; build ran clean).

## Verification
- Grepped `inc/` and `assets/` for all `auto-fit`/`auto-fill` grids — no other unsafe grids remain (no bbpress.css grids present).
- Ran `node scripts/build-design-system.js` → built successfully (809 lines); artifact diff is surgical and matches the source edits only.

Refs #16