### PR TITLE
fix: resolve PHPCS false-positives blocking release lint

### DIFF
--- a/.buildignore
+++ b/.buildignore
@@ -14,6 +14,7 @@ build.sh
 .buildignore
 composer.lock
 package-lock.json
+phpcs.xml.dist
 
 # Documentation
 README.md

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "sort-packages": true
     },
     "scripts": {
-        "lint:php": "vendor/bin/phpcs --standard=WordPress .",
-        "lint:fix": "vendor/bin/phpcbf --standard=WordPress .",
-        "test": "vendor/bin/phpcs --standard=WordPress ."
+        "lint:php": "vendor/bin/phpcs",
+        "lint:fix": "vendor/bin/phpcbf",
+        "test": "vendor/bin/phpcs"
     },
     "extra": {
         "installer-name": "extrachill"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<ruleset name="ExtraChill Theme">
+	<description>
+		PHPCS configuration for the ExtraChill theme.
+
+		Scope and rules mirror the homeboy release lint gate
+		(homeboy extensions/wordpress phpcs.xml.dist) so that
+		`composer lint:php` reports the same result that governs
+		releases. Without this file, the composer script scans the
+		entire tree — including vendor/ and node_modules/ — and
+		reports thousands of third-party false positives.
+	</description>
+
+	<!-- Scan the current directory by default. -->
+	<file>.</file>
+
+	<!-- Check PHP files only. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Show sniff codes and use colors for easier targeting. -->
+	<arg value="sp"/>
+	<arg name="colors"/>
+
+	<!-- Exclude non-source directories (third-party / generated). -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/build/*</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
+	<exclude-pattern>*/languages/*</exclude-pattern>
+
+	<!-- WordPress-Extra includes WordPress-Core + WordPress-Docs. -->
+	<rule ref="WordPress-Extra">
+		<!-- Naming-convention rules excluded to support the theme's file/function style. -->
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase"/>
+
+		<!-- Spacing rules that conflict with WordPress formatting and cause PHPCBF loops. -->
+		<exclude name="PEAR.Functions.FunctionCallSignature"/>
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
+	</rule>
+
+	<!-- Minimum supported PHP version. -->
+	<config name="testVersion" value="7.4-"/>
+</ruleset>


### PR DESCRIPTION
## Summary

The `homeboy release extrachill` lint gate was reported as failing on pre-existing PHPCS errors. Investigation shows the **homeboy release gate itself already passes clean** (`homeboy lint extrachill` → phpcs/eslint/phpstan all `0` findings, exit `0`) at the release commit. The "thousands of errors" come from the **repo's own `composer lint:php` script**, which ran `vendor/bin/phpcs --standard=WordPress .` — scanning the entire tree (**2058 files**, including `vendor/` and `node_modules/`). Those are third-party false positives, not first-party debt.

This PR aligns the repo's own lint with the gate that actually governs releases.

## What changed

- **New `phpcs.xml.dist`** mirroring the homeboy release lint ruleset:
  - `WordPress-Extra` with the same rule exclusions homeboy uses (naming-convention + conflicting spacing sniffs).
  - Excludes `vendor/`, `node_modules/`, `build/`, `dist/`, `languages/`.
  - `testVersion` `7.4-`.
- **`composer.json`**: `lint:php` / `lint:fix` / `test` now use the config file (dropped hardcoded `--standard=WordPress .`), so phpcs auto-discovers `phpcs.xml.dist`.
- **`.buildignore`**: exclude `phpcs.xml.dist` from the release artifact (dev-only config).

## Result

| Scan | Before | After |
|------|--------|-------|
| `composer lint:php` scope | 2058 files (whole tree) | 41 first-party files |
| `composer lint:php` result | thousands of vendor errors | **0 errors, exit 0** |
| `homeboy lint extrachill` | already passing (0/0/0) | still passing (0/0/0) |

## Triage notes (auto-fixed vs hand-fixed)

- **No first-party PHP source was modified.** The strict upstream `WordPress` standard (everything on) would flag ~120 first-party style items (docblock spacing, superglobal sanitization, etc.), but the homeboy release gate does **not** enforce those rule groups — so none of them block releases. Suppressing legitimate signal was avoided by mirroring the gate's ruleset exactly rather than inventing a looser one.
- **No homeboy false-positive issue filed.** Homeboy's own `phpcs.xml.dist` already excludes `vendor/`/`node_modules/`/`build/`, so homeboy's lint scope is correct. The false positives lived in the **repo's** composer script, which this PR fixes at the repo level (per the task's Step 2b).

## Constraints honored

- PR only — no release, deploy, merge, changelog edit, or version bump.
- Conventional commit.