### PR TITLE
docs: drop stale IBE references from theme comment and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,8 +242,9 @@ everything on every page.
 ### Blocks Everywhere editor iframe
 
 `blocks_everywhere_enqueue_iframe_assets` hook (in `inc/core/assets.php`)
-loads `root.css` + `style.css` + `block-editor.css` into the BE/IBE
-iframe so the editor visually matches the rendered front-end.
+loads `root.css` + `style.css` + `block-editor.css` into the Blocks
+Everywhere editor iframe so the editor visually matches the rendered
+front-end.
 
 ## Integration with Network Plugins
 

--- a/assets/css/block-editor.css
+++ b/assets/css/block-editor.css
@@ -31,8 +31,7 @@
    footer) inside a single .blocks-everywhere-editor wrapper. Without a
    container border the editor has no visible bounds against the host page
    chrome (Studio's "Submit for Review" buttons sit immediately below).
-   Pre-#26 the equivalent border came from .iso-editor's frame; restore it
-   on the modern wrapper.
+   Restore the structural border on the .blocks-everywhere-editor wrapper.
    ========================================================================== */
 
 .gutenberg-support .blocks-everywhere-editor {
@@ -101,7 +100,7 @@
    3. Toolbar Inserter (+) — Host React Tree
    BE renders <Inserter /> inside .blocks-everywhere-editor__toolbar, which
    produces .block-editor-inserter > .block-editor-inserter__toggle.components-button.
-   The button is colored with the EC accent (matches the previous IBE-era
+   The button is colored with the EC accent (matches the earlier
    .editor-document-tools__inserter-toggle.is-primary intent), but sized
    like the rest of the toolbar icon buttons (undo / redo / list-view /
    format buttons) so it doesn't dominate the row visually. Gutenberg's


### PR DESCRIPTION
## Summary

The Isolated Block Editor (IBE) was removed from the platform; Blocks Everywhere is now independent and renders the `.blocks-everywhere-editor` DOM directly. The theme had **no dead code** — only stale **textual** references to the removed IBE layer. This PR cleans up those references. **No functional CSS/PHP/JS changed** — comment and docs prose only.

## Changes

- **`assets/css/block-editor.css` (line 34)** — reworded the section-1 comment. It referenced `.iso-editor`'s frame as the historical source of the editor border. The actual selector below already correctly targets `.blocks-everywhere-editor`; only the *comment* was stale. Reworded to describe the border being restored on the modern wrapper without naming the dead `.iso-editor` class.
- **`assets/css/block-editor.css` (line 104)** — reworded the section-3 comment. It described the inserter button color as matching the "previous IBE-era" intent. Dropped the "IBE-era" phrasing ("matches the earlier …" intent). The historical Gutenberg selector referenced in the parenthetical (`.editor-document-tools__inserter-toggle.is-primary`) is left intact — it describes prior intent, not a dead IBE class.
- **`AGENTS.md` (Blocks Everywhere editor iframe section)** — reworded "loads … into the **BE/IBE** iframe" → "loads … into the **Blocks Everywhere editor** iframe". Hook name (`blocks_everywhere_enqueue_iframe_assets`) and technical description unchanged.

## Verification

Grepped the repo for `iso-editor|isolated.block.editor|IBE|BE/IBE` (excluding `node_modules`). After these edits, the only remaining match in tracked files is:

- **`docs/CHANGELOG.md`** line 130 — `restore structural borders for block editor shell after IBE migration`, a historical entry under released version **2.4.4**. Left untouched: CHANGELOG.md is owned by homeboy and is off-limits for manual edits per repo conventions.

No functional rules or selectors were modified — `git diff` confirms comment/prose text only.