### PR TITLE
fix: stop deregistering jQuery on frontend, keep dequeue-only

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -195,6 +195,5 @@ function extrachill_dequeue_jquery_frontend() {
 	}
 
 	wp_dequeue_script( 'jquery' );
-	wp_deregister_script( 'jquery' );
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_dequeue_jquery_frontend', 100 );


### PR DESCRIPTION
## Summary

Removes `wp_deregister_script( 'jquery' )` from `extrachill_dequeue_jquery_frontend()` while keeping `wp_dequeue_script( 'jquery' )`. This eliminates the `_doing_it_wrong` notices caused by WooCommerce handles declaring jQuery as a dependency against an unregistered handle.

Closes #67

## Root cause

`functions.php` ran both `wp_dequeue_script( 'jquery' )` **and** `wp_deregister_script( 'jquery' )` on every non-admin frontend request (priority 100 on `wp_enqueue_scripts`). The deregister destroyed the jquery registration entirely.

WooCommerce registers handles like `wc-add-to-cart` and `woocommerce` that declare `jquery` as a dependency. When `WP_Dependencies::all_deps()` (`wp-includes/class-wp-dependencies.php:217-228`) resolves a handle's dependency graph, it checks:

```php
$missing_dependencies = array_diff( $this->registered[ $handle ]->deps, array_keys( $this->registered ) );
```

Because `wp_deregister_script()` removed `jquery` from `$this->registered`, `array_keys( $this->registered )` no longer contained `jquery` — so it showed up as a missing dependency and core fired `_doing_it_wrong( 'WP_Scripts::add', ... )` (since `6.9.1`).

**Volume:** 4,833 notices over 28 days — the highest-volume error signature on the platform.

## Fix approach chosen: dequeue-only (remove deregister)

I verified the preferred approach against core dependency resolution before committing.

- **`wp_dequeue_script()`** removes a handle from `$this->queue` only — the handle stays in `$this->registered`.
- **`wp_deregister_script()`** removes a handle from `$this->registered` — destroying the registration.

With dequeue-only, the dependency check passes because `jquery` remains in `array_keys( $this->registered )` → no missing dependency → **no notice**.

### Does jquery still get suppressed from printing?

Yes. `do_items()` (`class-wp-dependencies.php:139`) processes `$this->queue`, and jquery is no longer in the queue. It is only pulled back into the `$to_do` list if a registered, enqueued handle recurses into it as a dependency (`all_deps()` line 232). So:

- **Editorial pages** (no jquery-dependent scripts enqueued): jquery is not printed. The jQuery-free-frontend perf intent is preserved.
- **WooCommerce pages** (`wc-add-to-cart`, etc.): those handles pull jquery back in via dependency recursion, so jquery prints exactly where it is actually needed.

### Why not the alternative (gate on WooCommerce context)?

The WooCommerce-context guard (`is_woocommerce() || is_cart() || is_checkout() || is_account_page()`) is a valid fallback, but it only covers the known offender (WooCommerce) and would need extending for every future plugin that declares a jquery dependency. Dequeue-only is a general fix: it kills the notice for **all** jquery-dependent handles while preserving the perf intent everywhere jquery isn't actually needed. It is strictly better here.

## What changed

`functions.php`, `extrachill_dequeue_jquery_frontend()` — one line removed:

```diff
 wp_dequeue_script( 'jquery' );
-wp_deregister_script( 'jquery' );
```

The `extrachill_dequeue_jquery_frontend` filter and `is_admin()` guard are unchanged.

## Notes

- jQuery-free-frontend perf intent is fully preserved (jquery still dequeued).
- No version bump / CHANGELOG edits — homeboy owns both.