### PR TITLE
fix: scope PHPCS to theme source, unblock releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "sort-packages": true
     },
     "scripts": {
-        "lint:php": "vendor/bin/phpcs --standard=WordPress .",
-        "lint:fix": "vendor/bin/phpcbf --standard=WordPress .",
-        "test": "vendor/bin/phpcs --standard=WordPress ."
+        "lint:php": "vendor/bin/phpcs",
+        "lint:fix": "vendor/bin/phpcbf",
+        "test": "vendor/bin/phpcs"
     },
     "extra": {
         "installer-name": "extrachill"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<ruleset name="Extra Chill Theme">
+	<description>PHPCS ruleset for the Extra Chill theme — scopes the scan to first-party source only.</description>
+
+	<!-- Scan the theme's own PHP, not dependencies or build output. -->
+	<file>.</file>
+
+	<!-- Never scan vendored or generated code. -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/languages/*</exclude-pattern>
+	<exclude-pattern>*/assets/*</exclude-pattern>
+
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Show progress, use colors, run in parallel. -->
+	<arg value="p"/>
+	<arg name="colors"/>
+	<arg name="parallel" value="8"/>
+
+	<rule ref="WordPress"/>
+
+	<!-- Match the composer PHP compatibility target. -->
+	<config name="testVersion" value="7.4-"/>
+</ruleset>


### PR DESCRIPTION
## Summary

`composer test` (and `lint:php`) ran `phpcs --standard=WordPress .`, which scanned **1,295 PHP files — 1,254 of them in `vendor/`** (WPCS, PHPCompatibility, composer internals). That full-tree scan takes >10 minutes and exceeded Composer's `process-timeout`, failing **every** `homeboy release` preflight for the theme.

## Root cause

- Theme has only ~41 first-party PHP files.
- `phpcs ... .` with no scoping crawls `vendor/` and `node_modules/` too.
- Bumping `process-timeout` (even to 600s) did **not** help — the scan genuinely takes >10 min because it's linting dependencies. Treating the symptom, not the disease.

## Fix

- Add `phpcs.xml.dist` that scopes the scan to theme source, excludes `vendor/`, `node_modules/`, `languages/`, `assets/`, restricts to `.php`, enables `--parallel=8`, and pins `testVersion` to `7.4-`.
- Simplify composer scripts to bare `phpcs` / `phpcbf` so they auto-discover the ruleset.

This makes `composer test` scan ~41 files in seconds instead of 1,295 in >10 min, permanently unblocking theme releases.

## Follow-up (separate layer)

homeboy-extensions' composer-script backend does not set a default `COMPOSER_PROCESS_TIMEOUT`, so any component with a slow lint silently fails a release. Worth a tracked enhancement. Filed separately.

## Facts
- Before: 1,295 files scanned (1,254 in vendor), >10 min, release preflight timeout
- After: ~41 theme files scanned, seconds
- Files: `composer.json`, `phpcs.xml.dist`