### PR TITLE
fix: align PHPCS ruleset to homeboy release gate (WordPress-Extra, not strict WordPress)

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Extra Chill Theme">
-	<description>PHPCS ruleset for the Extra Chill theme — scopes the scan to first-party source only.</description>
+	<description>PHPCS ruleset for the Extra Chill theme. Mirrors the homeboy release lint gate (WordPress-Extra + the same exclusions) and scopes the scan to first-party source, so `composer test` matches what governs releases.</description>
 
 	<!-- Scan the theme's own PHP, not dependencies or build output. -->
 	<file>.</file>
@@ -8,18 +8,38 @@
 	<!-- Never scan vendored or generated code. -->
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/build/*</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
 	<exclude-pattern>*/languages/*</exclude-pattern>
 	<exclude-pattern>*/assets/*</exclude-pattern>
 
 	<!-- Only check PHP files. -->
 	<arg name="extensions" value="php"/>
 
-	<!-- Show progress, use colors, run in parallel. -->
-	<arg value="p"/>
+	<!-- Show sniff codes, progress, colors, run in parallel. -->
+	<arg value="sp"/>
 	<arg name="colors"/>
 	<arg name="parallel" value="8"/>
 
-	<rule ref="WordPress"/>
+	<!--
+		WordPress-Extra (Core + Docs) with the exact exclusions the homeboy
+		release lint gate applies. Keeping these in sync means a clean
+		`composer test` guarantees a clean release preflight.
+	-->
+	<rule ref="WordPress-Extra">
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase"/>
+
+		<!-- PEAR/Squiz function spacing rules that conflict with WordPress formatting. -->
+		<exclude name="PEAR.Functions.FunctionCallSignature"/>
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
+	</rule>
 
 	<!-- Match the composer PHP compatibility target. -->
 	<config name="testVersion" value="7.4-"/>


### PR DESCRIPTION
## Summary

The `phpcs.xml.dist` introduced in #69 used the full strict `WordPress` standard. That is too strict for this codebase — it flags ~120 pre-existing first-party style items (missing docblocks, superglobal sanitization, comment punctuation) that the **actual homeboy release lint gate does not enforce**. As a result the last release had to go through `--skip-checks`.

This PR swaps to `WordPress-Extra` (Core + Docs) with the exact exclusions the homeboy gate applies, so that **`composer test` == release preflight** and `--skip-checks` is no longer needed.

## Why strict `WordPress` was wrong

The homeboy release gate (see `homeboy-extensions/wordpress/phpcs.xml.dist`) does **not** use the full `WordPress` standard. It uses `WordPress-Extra` with these specific exclusions:

- `WordPress.Files.FileName.NotHyphenatedLowercase`
- `WordPress.Files.FileName.InvalidClassFileName`
- `WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid`
- `WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase`
- `WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase`
- `WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase`
- `WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase`
- `PEAR.Functions.FunctionCallSignature`
- `Squiz.Functions.FunctionDeclarationArgumentSpacing`
- `Squiz.Functions.MultiLineFunctionDeclaration`

The strict `WordPress` ruleset (from #69) pulled in `WordPress-VIP`, extra naming rules, and stricter sanitization/docblock sniffs that produced ~120 violations the gate never enforced. This PR mirrors the gate's ruleset verbatim so the repo's local preflight cannot diverge from what governs a release.

## Verification

`composer test` now exits 0 on first-party code with no errors:

```
....... 7 / 7 (100%)

Time: 491ms; Memory: 8MB
```

`composer lint:php` behaves identically (both scripts invoke `vendor/bin/phpcs`):

```
....... 7 / 7 (100%)

Time: 681ms; Memory: 8MB
```

Fast (<2s) and clean. No first-party source errors remain.

## Relationship to prior work

- Supersedes/closes the older #64 (`phpcs-fix`), which did the same investigation and reached the same conclusion. This PR lands that approach on top of current `main`.
- #69 is what introduced the overly-strict `WordPress` ruleset this corrects.

## Notes

- **No first-party PHP source was modified.** The whole point is to align the ruleset to the gate, not to hand-fix ~120 style items.
- Also adds `build/*` and `dist/*` exclude-patterns (present in the gate) and an `s` arg flag so sniff codes show in reports, matching the gate's report style.