### PR TITLE
fix: skip jQuery dequeue on WooCommerce sites to stop notice flood

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -189,6 +189,13 @@ function extrachill_dequeue_jquery_frontend() {
 		return;
 	}
 
+	// WooCommerce scripts depend on jquery; dequeuing it fires a doing_it_wrong
+	// notice on every shop page load (~365/day network-wide). Bail before the filter
+	// so Woo sites are always safe regardless of the filter default.
+	if ( function_exists( 'WC' ) || class_exists( 'WooCommerce' ) ) {
+		return;
+	}
+
 	$should_dequeue = apply_filters( 'extrachill_dequeue_jquery_frontend', true );
 	if ( ! $should_dequeue ) {
 		return;


### PR DESCRIPTION
## Root cause

The Extra Chill theme is network-active across the multisite. `extrachill_dequeue_jquery_frontend()` dequeues jQuery on every non-admin frontend request — which is the desired optimization on the main blog (no jQuery needed), but on **shop.extrachill.com** (blog 3) WooCommerce registers the `wc-add-to-cart` and `woocommerce` script handles with `jquery` as a declared dependency.

When the theme dequeues `jquery`, WP 6.9.1 fires this `doing_it_wrong` notice on every shop page load:

> Function WP_Scripts::add was called incorrectly. The script with the handle "wc-add-to-cart" was enqueued with dependencies that are not registered: jquery.

That is ~182/day for `wc-add-to-cart` + ~182/day for `woocommerce` = **~365/day, ~70% of the entire network `debug.log` noise**. It's a notice (not a fatal — the shop stays up), but it drowns the log and hides real signals.

## The fix

Added a WooCommerce guard inside `extrachill_dequeue_jquery_frontend()` (functions.php):

```php
// Bail before the filter so Woo sites are always safe regardless of the filter default.
if ( function_exists( 'WC' ) || class_exists( 'WooCommerce' ) ) {
    return;
}
```

### Why the guard sits **before** the `extrachill_dequeue_jquery_frontend` filter

The filter is the existing escape hatch and stays fully working for non-Woo sites. But the shop-site invariant — **on a site with WooCommerce active, jQuery must NOT be dequeued** — needs to hold regardless of the filter's default. Placing the WooCommerce check before the filter makes the invariant unconditional: a plugin can't accidentally re-enable the dequeue on the shop site via the filter and reintroduce the notice flood.

### Why a targeted Woo guard, not a generic "any script depends on jquery" guard

The generic approach (walk `$wp_scripts->queue` and bail if any still-enqueued handle lists `jquery` as a dependency) was considered. It's more general but adds per-request iteration over the script queue with no observed benefit beyond what the Woo guard solves. The WooCommerce notice is the only known source of this flood in the network log. If a second jquery-dependent surface appears later, a generic guard can be introduced then — premature consolidation here would be the anti-pattern.

## Verification

- **Main-site path preserved:** with WooCommerce absent (main blog, community, events, etc.), the function still dequeues jQuery — the optimization is intact.
- **Shop/WooCommerce path fixed:** on shop.extrachill.com the guard short-circuits before `wp_dequeue_script( 'jquery' )`, so Woo's dependencies resolve and the notice stops.
- **`homeboy review extrachill lint`: passed** — PHPCS, PHPStan (level 7), and ESLint all clean, 0 findings. Keeps the strict ruleset aligned in #69/#70 happy.
- No build step for this theme.

## Scope of work this completes

This completes the jQuery-handling work started in #67/#68, which switched from `wp_deregister_script` → `wp_dequeue_script` (correctly preserving the handle so dependents don't fatal) but left the shop-site notice because the dequeue still ran network-wide. This PR scopes the dequeue so Woo sites are excluded.

No release, no deploy, no CHANGELOG/version bump — PR only.