### PR TITLE
Add back-to-top navigation for long pages

### DIFF
--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -1,0 +1,52 @@
+( function () {
+	const button = document.querySelector( '.back-to-top' );
+	const target = document.getElementById( 'masthead' );
+
+	if ( ! button || ! target ) {
+		return;
+	}
+
+	let ticking = false;
+
+	function updateVisibility() {
+		const isVisible = window.scrollY > Math.max( 600, window.innerHeight );
+		button.classList.toggle( 'is-visible', isVisible );
+		button.setAttribute( 'aria-hidden', String( ! isVisible ) );
+		button.tabIndex = isVisible ? 0 : -1;
+		ticking = false;
+	}
+
+	window.addEventListener(
+		'scroll',
+		function () {
+			if ( ! ticking ) {
+				window.requestAnimationFrame( updateVisibility );
+				ticking = true;
+			}
+		},
+		{ passive: true }
+	);
+
+	button.addEventListener( 'click', function () {
+		const reduceMotion = window.matchMedia(
+			'(prefers-reduced-motion: reduce)'
+		).matches;
+
+		window.scrollTo( {
+			top: 0,
+			behavior: reduceMotion ? 'auto' : 'smooth',
+		} );
+
+		target.tabIndex = -1;
+		target.focus( { preventScroll: true } );
+		target.addEventListener(
+			'blur',
+			function () {
+				target.removeAttribute( 'tabindex' );
+			},
+			{ once: true }
+		);
+	} );
+
+	updateVisibility();
+} )();

--- a/functions.php
+++ b/functions.php
@@ -130,6 +130,7 @@ require_once EXTRACHILL_INCLUDES_DIR . '/core/templates/taxonomy-badges.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/actions.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/assets.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/icons.php';
+require_once EXTRACHILL_INCLUDES_DIR . '/core/back-to-top.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/notices.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/rewrite.php';
 require_once EXTRACHILL_INCLUDES_DIR . '/core/site-title.php';

--- a/inc/core/back-to-top.php
+++ b/inc/core/back-to-top.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Back-to-top navigation for long singular views.
+ *
+ * @package ExtraChill
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Determine whether the current view should include back-to-top navigation.
+ *
+ * @return bool
+ */
+function extrachill_should_show_back_to_top() {
+	return (bool) apply_filters( 'extrachill_show_back_to_top', is_singular() );
+}
+
+/**
+ * Enqueue back-to-top behavior only where the control can render.
+ */
+function extrachill_enqueue_back_to_top() {
+	if ( ! extrachill_should_show_back_to_top() ) {
+		return;
+	}
+
+	$script_path = get_template_directory() . '/assets/js/back-to-top.js';
+	if ( ! file_exists( $script_path ) ) {
+		return;
+	}
+
+	wp_enqueue_script(
+		'extrachill-back-to-top',
+		get_template_directory_uri() . '/assets/js/back-to-top.js',
+		array(),
+		(string) filemtime( $script_path ),
+		array(
+			'strategy'  => 'defer',
+			'in_footer' => true,
+		)
+	);
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_enqueue_back_to_top' );
+
+/**
+ * Render the progressively enhanced back-to-top control.
+ */
+function extrachill_render_back_to_top() {
+	if ( ! extrachill_should_show_back_to_top() ) {
+		return;
+	}
+	?>
+	<button class="back-to-top" type="button" aria-label="<?php esc_attr_e( 'Back to top', 'extrachill' ); ?>" aria-hidden="true" tabindex="-1">
+		<?php echo ec_icon( 'circle-up-outline' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_icon() returns escaped SVG markup from the theme sprite. ?>
+	</button>
+	<?php
+}
+add_action( 'wp_footer', 'extrachill_render_back_to_top', 5 );

--- a/style.css
+++ b/style.css
@@ -41,6 +41,58 @@ html {
 	-ms-text-size-adjust: 100%;
 }
 
+.back-to-top {
+	align-items: center;
+	background: var(--accent-2);
+	border: 0;
+	border-radius: var(--border-radius-circle);
+	bottom: var(--spacing-lg);
+	box-shadow: var(--card-hover-shadow);
+	color: var(--button-text-color);
+	cursor: pointer;
+	display: flex;
+	height: 3rem;
+	justify-content: center;
+	left: var(--spacing-lg);
+	opacity: 0;
+	pointer-events: none;
+	position: fixed;
+	transform: translateY(0.75rem);
+	transition: opacity var(--transition-normal), transform var(--transition-normal), visibility var(--transition-normal);
+	visibility: hidden;
+	width: 3rem;
+	z-index: 1000;
+}
+
+.back-to-top.is-visible {
+	opacity: 1;
+	pointer-events: auto;
+	transform: translateY(0);
+	visibility: visible;
+}
+
+.back-to-top:hover {
+	background: var(--link-color-hover);
+}
+
+.back-to-top:focus-visible {
+	box-shadow: var(--focus-box-shadow);
+	outline: 2px solid var(--focus-border-color);
+	outline-offset: 2px;
+}
+
+.back-to-top .ec-icon {
+	fill: currentColor;
+	height: 1.5rem;
+	width: 1.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.back-to-top {
+		transition: none;
+	}
+}
+
 article, aside, details, figcaption, figure, footer, header, main, nav, section {
 	display: block;
 }


### PR DESCRIPTION
## Summary
- add a reusable back-to-top primitive for singular views, including blog posts and community topics
- reveal the control only after meaningful scrolling and place it bottom-left to avoid the Roadie/chat launcher
- support keyboard focus, reduced-motion preferences, theme tokens, and conditional asset loading

## Testing
- `php -l inc/core/back-to-top.php`
- `php -l functions.php`
- `node --check assets/js/back-to-top.js`
- `composer test`
- `git diff --check`

The Homeboy umbrella was not forced because host resource policy reported load average 79.0 on 8 CPUs. The full theme PHPCS gate and focused checks above passed.

Closes #73
