### PR TITLE
fix: alternate venue badge contrast

### DIFF
--- a/assets/css/taxonomy-badges.css
+++ b/assets/css/taxonomy-badges.css
@@ -985,3 +985,22 @@
     background-color: var(--badge-artist-susto-bg);
     color: var(--badge-artist-susto-text);
 }
+
+/* === Venue Badge Checker === */
+.taxonomy-badge.venue-badge {
+  background-color: var(--badge-venue-default-bg);
+  color: var(--badge-venue-default-text);
+  border-color: var(--badge-venue-default-bg);
+}
+
+.taxonomy-badges > .taxonomy-badge.venue-badge:nth-child(even of .venue-badge) {
+  background-color: var(--badge-venue-default-text);
+  color: var(--badge-venue-default-bg);
+  border-color: var(--badge-venue-default-bg);
+}
+
+.taxonomy-badge.venue-badge:hover,
+.taxonomy-badges > .taxonomy-badge.venue-badge:nth-child(even of .venue-badge):hover {
+  background-color: var(--badge-venue-default-bg);
+  color: var(--badge-venue-default-text);
+}

--- a/scripts/build-taxonomy-badges.js
+++ b/scripts/build-taxonomy-badges.js
@@ -50,7 +50,27 @@ const tokensCSS = fs.readFileSync(
   'utf8'
 );
 
-const output = baseStyles + '\n' + tokensCSS;
+const venueStyles = `/* === Venue Badge Checker === */
+.taxonomy-badge.venue-badge {
+  background-color: var(--badge-venue-default-bg);
+  color: var(--badge-venue-default-text);
+  border-color: var(--badge-venue-default-bg);
+}
+
+.taxonomy-badges > .taxonomy-badge.venue-badge:nth-child(even of .venue-badge) {
+  background-color: var(--badge-venue-default-text);
+  color: var(--badge-venue-default-bg);
+  border-color: var(--badge-venue-default-bg);
+}
+
+.taxonomy-badge.venue-badge:hover,
+.taxonomy-badges > .taxonomy-badge.venue-badge:nth-child(even of .venue-badge):hover {
+  background-color: var(--badge-venue-default-bg);
+  color: var(--badge-venue-default-text);
+}
+`;
+
+const output = baseStyles + '\n' + tokensCSS + '\n' + venueStyles;
 const outPath = path.join(__dirname, '..', 'assets', 'css', 'taxonomy-badges.css');
 
 fs.writeFileSync(outPath, output);


### PR DESCRIPTION
## Summary
- alternate venue badges black/white then white/black within taxonomy badge collections
- keep isolated venue badges black with white text
- override legacy per-venue colors without changing location/city badge colors
- generate the behavior from the theme build source so the artifact stays reproducible

## Verification
- `npm run build`
- `node --check scripts/build-taxonomy-badges.js`
- `git diff --check`

Closes #76