### PR TITLE
fix: consume alternating venue badges

### DIFF
--- a/assets/css/taxonomy-badges.css
+++ b/assets/css/taxonomy-badges.css
@@ -36,7 +36,7 @@
  * Generated from @extrachill/tokens — DO NOT EDIT MANUALLY.
  * Source: tokens.json > categories > taxonomy-badge
  *
- * 233 badges across 5 taxonomies
+ * 228 badges across 5 taxonomies
  */
 
 /* === Festival Badges === */
@@ -957,26 +957,18 @@
 .taxonomy-badge.venue-badge {
     background-color: var(--badge-venue-default-bg);
     color: var(--badge-venue-default-text);
+    border-color: var(--badge-venue-default-bg);
 }
-.taxonomy-badge.venue-the-royal-american {
-    background-color: var(--badge-venue-the-royal-american-bg);
-    color: var(--badge-venue-the-royal-american-text);
+
+.taxonomy-badges > .taxonomy-badge.venue-badge:nth-child(even of .venue-badge) {
+    background-color: var(--badge-venue-default-text);
+    color: var(--badge-venue-default-bg);
+    border-color: var(--badge-venue-default-bg);
 }
-.taxonomy-badge.venue-the-bounty-bar {
-    background-color: var(--badge-venue-the-bounty-bar-bg);
-    color: var(--badge-venue-the-bounty-bar-text);
-}
-.taxonomy-badge.venue-the-refinery {
-    background-color: var(--badge-venue-the-refinery-bg);
-    color: var(--badge-venue-the-refinery-text);
-}
-.taxonomy-badge.venue-lo-fi-brewing {
-    background-color: var(--badge-venue-lo-fi-brewing-bg);
-    color: var(--badge-venue-lo-fi-brewing-text);
-}
-.taxonomy-badge.venue-charleston-tin-roof {
-    background-color: var(--badge-venue-charleston-tin-roof-bg);
-    color: var(--badge-venue-charleston-tin-roof-text);
+.taxonomy-badge.venue-badge:hover,
+.taxonomy-badges > .taxonomy-badge.venue-badge:nth-child(even of .venue-badge):hover {
+    background-color: var(--badge-venue-default-bg);
+    color: var(--badge-venue-default-text);
 }
 
 /* === Artist Badges === */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "extrachill-theme",
-  "version": "2.0.12",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extrachill-theme",
-      "version": "2.0.12",
+      "version": "2.12.0",
       "dependencies": {
-        "@extrachill/tokens": "github:Extra-Chill/extrachill-tokens#v0.8.1"
+        "@extrachill/tokens": "github:Extra-Chill/extrachill-tokens#v0.8.2"
       }
     },
     "node_modules/@extrachill/tokens": {
-      "version": "0.8.1",
-      "resolved": "git+ssh://git@github.com/Extra-Chill/extrachill-tokens.git#be04920249e0c48780de8922f6b2849dd0c25ffa",
+      "version": "0.8.2",
+      "resolved": "git+ssh://git@github.com/Extra-Chill/extrachill-tokens.git#2b66862ad60dc6ce42892540d05c13c40a3e48e2",
       "license": "GPL-2.0+"
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "build": "cp node_modules/@extrachill/tokens/css/root.css assets/css/root.css && cp node_modules/@extrachill/tokens/css/theme.json theme.json && node scripts/build-taxonomy-badges.js && node scripts/build-design-system.js"
   },
   "dependencies": {
-    "@extrachill/tokens": "github:Extra-Chill/extrachill-tokens#v0.8.1"
+    "@extrachill/tokens": "github:Extra-Chill/extrachill-tokens#v0.8.2"
   }
 }


### PR DESCRIPTION
## Summary
- update `@extrachill/tokens` from v0.8.1 to v0.8.2
- rebuild taxonomy badge CSS from the released token source
- replace named venue colors with alternating black/white venue badges
- preserve existing location/city colors

## Verification
- `npm ci --ignore-scripts`
- `npm run build`
- `node --check scripts/build-taxonomy-badges.js`
- `git diff --check`

Consumes Extra-Chill/extrachill-tokens#5 and [v0.8.2](https://github.com/Extra-Chill/extrachill-tokens/releases/tag/v0.8.2).